### PR TITLE
fix(datahub): Phase 3 & 4 code quality improvements and type guidelines

### DIFF
--- a/.claude/rules/backend/polars.md
+++ b/.claude/rules/backend/polars.md
@@ -315,6 +315,195 @@ def list_sids(self, dataset: str) -> list[int]:
 - 日期使用 Python `datetime.date` 而非 `pl.date()`
 - 日期解析用 `datetime.strptime()` + `pl.lit()`
 
+## 类型安全与 Schema
+
+### Polars 运行时类型安全
+
+Polars LazyFrame 在 Plan 阶段就能验证 Schema，提供了比 TypedDict 更好的类型安全。
+
+```python
+# ✅ Good: Schema 定义让 Polars 在执行前验证
+schema = {
+    "sid": pl.Int64,
+    "trade_date": pl.Date,
+    "open": pl.Float64,
+    "high": pl.Float64,
+    "low": pl.Float64,
+    "close": pl.Float64,
+    "volume": pl.UInt64,
+}
+
+# LazyFrame 在 Plan 阶段就能捕获错误
+lf = pl.scan_parquet("data.parquet").select([
+    pl.col("close"),   # ✅ 列存在，Plan 阶段通过
+    pl.col("typo"),    # ❌ 列不存在，Plan 阶段报错
+])
+```
+
+### 为什么不需要 TypedDict
+
+```python
+# ❌ 反模式: TypedDict 维护成本高，容易与实际 Schema 不一致
+from typing import TypedDict
+
+class OHLCVRow(TypedDict):
+    """OHLCV data row."""
+    sid: int
+    trade_date: date
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+
+def process_row(row: OHLCVRow) -> float:
+    """Process a single row."""
+    return (row["high"] - row["low"]) / row["close"]
+
+# ❌ 问题:
+# 1. Schema 变更需要同步更新 TypedDict
+# 2. 容易与实际 Schema 不一致
+# 3. 违反向量化原则
+
+
+# ✅ 推荐: 直接使用 DataFrame，让 Polars 提供类型安全
+def process_dataframe(df: pl.DataFrame) -> pl.DataFrame:
+    """Process OHLCV data as DataFrame.
+
+    Polars 在 Plan 阶段就能验证列名和类型，
+    比 TypedDict 提供更早的错误检测。
+    """
+    return df.with_columns(
+        ((pl.col("high") - pl.col("low")) / pl.col("close")).alias("range_pct")
+    )
+```
+
+### Schema 验证最佳实践
+
+```python
+# ✅ 在数据边界验证 Schema
+def validate_bars_schema(df: pl.DataFrame) -> None:
+    """Validate bars DataFrame schema.
+
+    在数据写入或读取时验证，确保整个系统使用一致的 Schema。
+    """
+    expected_schema = {
+        "sid": pl.Int64,
+        "trade_date": pl.Date,
+        "open": pl.Float64,
+        "high": pl.Float64,
+        "low": pl.Float64,
+        "close": pl.Float64,
+        "volume": pl.UInt64,
+    }
+
+    # 检查列名
+    missing = set(expected_schema.keys()) - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing columns: {missing}")
+
+    extra = set(df.columns) - set(expected_schema.keys())
+    if extra:
+        raise ValueError(f"Unexpected columns: {extra}")
+
+    # 检查类型
+    for col, expected_dtype in expected_schema.items():
+        actual_dtype = df.schema[col]
+        if actual_dtype != expected_dtype:
+            raise TypeError(
+                f"Column '{col}': expected {expected_dtype}, got {actual_dtype}"
+            )
+
+
+# ✅ 使用 LazyFrame 的 schema 属性
+def safe_query(df: pl.DataFrame) -> pl.DataFrame:
+    """Safe query with schema validation."""
+    lf = df.lazy()
+
+    # Plan 阶段就能捕获错误
+    result = (
+        lf
+        .filter(pl.col("trade_date") >= pl.lit(date(2024, 1, 1)))
+        .select([
+            pl.col("close"),
+            pl.col("volume"),
+        ])
+    )
+
+    # 在 collect() 前验证输出 Schema
+    output_schema = result.collect_schema()
+    assert output_schema["close"] == pl.Float64
+
+    return result.collect()
+```
+
+### 类型注解与 MyPy
+
+```python
+# ✅ Polars 操作的返回类型注解
+def calculate_returns(df: pl.DataFrame) -> pl.DataFrame:
+    """Calculate daily returns.
+
+    Returns:
+        pl.DataFrame: DataFrame with additional 'returns' column.
+    """
+    return df.with_columns(
+        pl.col("close").pct_change().alias("returns")
+    )
+
+
+# ✅ 明确 Schema 约束（使用 pl.Enum）
+def filter_by_status(df: pl.DataFrame) -> pl.DataFrame:
+    """Filter orders by status."""
+    return df.filter(
+        pl.col("status").is_in(["pending", "submitted", "filled"])
+    )
+
+
+# ✅ 使用 cast 处理 Polars 类型推断的局限
+from typing import cast
+
+def get_first_close(df: pl.DataFrame) -> float:
+    """Get first close price."""
+    # item() 返回 Any，需要 cast
+    result = df.select(pl.col("close").first()).item()
+    return cast(float, result)
+```
+
+### Schema 演进策略
+
+```python
+# ✅ Schema 版本化
+class SchemaV1:
+    """Schema version 1."""
+    BARS = {
+        "sid": pl.Int64,
+        "trade_date": pl.Date,
+        "open": pl.Float64,
+        "high": pl.Float64,
+        "low": pl.Float64,
+        "close": pl.Float64,
+        "volume": pl.UInt64,
+    }
+
+
+class SchemaV2(SchemaV1):
+    """Schema version 2: added adj_factor column."""
+    BARS = {
+        **SchemaV1.BARS,
+        "adj_factor": pl.Float64,  # 新增列
+    }
+
+
+def migrate_schema(df: pl.DataFrame, from_v: int, to_v: int) -> pl.DataFrame:
+    """Migrate DataFrame between schema versions."""
+    if from_v == 1 and to_v == 2:
+        return df.with_columns(
+            pl.lit(1.0).alias("adj_factor")
+        )
+    raise NotImplementedError(f"Migration from v{from_v} to v{to_v}")
+```
+
 ## 禁止清单
 
 | 禁止 | 原因 | 替代方案 |

--- a/.claude/rules/backend/python-code-style.md
+++ b/.claude/rules/backend/python-code-style.md
@@ -232,6 +232,132 @@ from typing import cast
 result = cast(float, df.select(pl.col("value").mean()).item())
 ```
 
+### 3.4 DataFrame 驱动系统的类型策略
+
+**核心原则**: 在量化系统中，数据流向为 `SQLite → Polars DataFrame → 向量化运算`。
+中间层的 Row 对象（TypedDict）是冗余的，TypedDict 可能是反模式。
+
+#### 何时使用 TypedDict
+
+| 场景 | 是否使用 TypedDict | 原因 |
+|------|-------------------|------|
+| DataFrame 列数据 | ❌ 不使用 | Polars 提供运行时类型安全 |
+| SQL 直接返回值 | ✅ 可使用 | API 边界需要明确契约 |
+| 配置/元数据 | ✅ 推荐 | 静态结构，需要文档化 |
+| 测试 fixture | ✅ 推荐 | 明确预期结构 |
+
+#### 务实的类型注解策略
+
+```python
+# ✅ 好：使用具体类型替代 Any
+from ditto_datahub.types import DQResult
+
+@dataclass
+class WriteResult:
+    """Data write result."""
+    path: str
+    checksum: str
+    failed_checks: list[DQResult]  # 而非 list[Any]
+
+
+# ✅ 好：SQL 返回值使用具体联合类型
+def fetchval(
+    self, sql: str, params: list[Any] | tuple[Any, ...] | None = None
+) -> str | int | float | None:
+    """Fetch first column of first row.
+
+    Returns:
+        str | int | float | None: Value from the first column.
+    """
+    row = self.fetchone(sql, params)
+    if row:
+        return cast(str | int | float, row[0])
+    return None
+
+
+# ✅ 可接受：低频查询使用 dict[str, Any]
+def get_metadata(self) -> dict[str, Any]:
+    """Get flexible metadata.
+
+    低频调用、结构多变的情况，dict[str, Any] 是务实的妥协。
+    """
+    return self._meta
+
+
+# ❌ 避免：为 SQL 返回值创建 TypedDict
+class SecurityRow(TypedDict):
+    """Security data row from SQLite."""
+    sid: int
+    symbol: str
+    name: str | None
+    # ...
+
+def get_security(sid: int) -> SecurityRow:
+    """❌ 冗余：应该直接返回 DataFrame"""
+    ...
+
+# ✅ 推荐：返回 DataFrame，让 Polars 提供类型安全
+def get_securities(sids: list[int]) -> pl.DataFrame:
+    """Get securities as DataFrame.
+
+    Polars LazyFrame 在 Plan 阶段就能验证 Schema，提供更好的类型安全。
+    """
+    ...
+```
+
+#### 类型精确化的优先级
+
+| 优先级 | 问题类型 | 示例 | 是否修复 |
+|--------|----------|------|----------|
+| P0 | `Any` 返回类型 | `def foo() -> Any:` | ✅ 必须修复 |
+| P0 | `Any` 参数类型 | `def foo(x: Any):` | ✅ 必须修复 |
+| P1 | `list[Any]` 具体类型已知 | `list[DQResult]` | ✅ 建议修复 |
+| P2 | `dict[str, Any]` 灵活配置 | 元数据、配置 | ⚠️ 可保留 |
+| P3 | SQL 返回 TypedDict | `SecurityRow` | ❌ 反模式 |
+
+#### 类型别名最佳实践
+
+```python
+# ✅ 定义输入类型别名
+from datetime import date, datetime
+
+DateInput = str | date | datetime | None
+
+def normalize_date(value: DateInput) -> str | None:
+    """Normalize various date input types to YYYY-MM-DD string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        datetime.strptime(value, "%Y-%m-%d")
+        return value
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d")
+    if isinstance(value, date):
+        return value.strftime("%Y-%m-%d")
+    raise TypeError(f"Unsupported date type: {type(value)}")
+
+
+# ✅ 使用 Sequence 替代 list 提高灵活性
+from collections.abc import Sequence
+
+def get_symbols(symbols: Sequence[str]) -> pl.DataFrame:
+    """Accept any sequence of strings (list, tuple, set, etc.)."""
+    ...
+
+
+# ✅ 使用 Literal 限定字符串选项
+from typing import Literal
+
+AdjustmentType = Literal["qfq", "hfq", "none"]
+
+def apply_adjustment(
+    df: pl.DataFrame,
+    adj_type: AdjustmentType = "none",
+) -> pl.DataFrame:
+    """Apply price adjustment."""
+    ...
+```
+
 ---
 
 ## 4. 命名规范

--- a/docs/plans/2025-12-26-datahub-code-quality-fixes.md
+++ b/docs/plans/2025-12-26-datahub-code-quality-fixes.md
@@ -1,0 +1,370 @@
+# [Sprint 1] Code Quality: DataHub 代码修复
+
+**日期**: 2025-12-26
+**状态**: ❌ 未开始
+**分支**: `fix/datahub-code-quality`
+
+---
+
+## 🎯 技能使用计划
+
+> 本任务的 Superpowers 工作流：
+
+| 阶段 | 使用 Skill | 产出 |
+|------|-----------|------|
+| 设计 | `brainstorming` | 已完成（用户确认业务逻辑） |
+| 计划 | `writing-plans` | 本文件 |
+| 执行 | `executing-plans` + `test-driven-development` | 代码实现 |
+| 审查 | `requesting-code-review` | 代码质量检查 |
+| 完成 | `finishing-a-development-branch` | PR/合并决策 |
+
+---
+
+## 一、任务概述
+
+### 目标
+修复 DataHub 模块中发现的 14 个代码质量问题，涵盖业务逻辑正确性、数据安全和代码质量三个维度。
+
+### 问题汇总
+
+| 严重性 | 数量 | 主要问题 |
+|--------|------|----------|
+| **High** | 5 | 混合资产查询、QFQ 因子排序、SQL 注入风险、类型安全 |
+| **Medium** | 6 | 复权因子缺失、日期规范化、SQLite 外键、函数过长 |
+| **Low** | 3 | symbol 多重匹配、代码一致性、灵活性 |
+
+### 用户确认的业务逻辑
+1. **混合资产查询**: 抛出错误，不允许混合查询
+2. **复权因子缺失**: 可能缺失，应使用原始价格（未复权价格）
+3. **QFQ 最新因子**: 两者结合（存储时排序 + 查询时显式排序）
+
+### 依赖
+- 无前置任务
+- 依赖：现有测试框架已就绪
+
+### 复杂度评估
+- **任务规模**: L (复杂)
+- **是否需要 Plan 文件**: ✅ 是
+- **预估子任务数**: 14 个
+
+---
+
+## 二、设计阶段
+
+### 2.1 用户确认项
+- [x] 功能边界已明确（混合资产查询行为）
+- [x] 接口设计已确认（复权因子缺失处理策略）
+- [x] 数据结构已定义（使用 pl.coalesce 处理 null）
+- [x] 边界条件已讨论（所有业务逻辑已确认）
+
+### 2.2 关键设计决策
+
+| 决策 | 理由 |
+|------|------|
+| 混合资产查询抛出 ValueError | 防止静默数据丢失，强制用户明确意图 |
+| 复权因子缺失使用 pl.coalesce(..., 1.0) | 保证返回数据完整性，缺失时返回原始价格 |
+| QFQ 双重排序（存储+查询） | 防御性编程，即使数据未排序也能正确工作 |
+| SQLite 启用外键约束 | 确保 referential integrity，防止孤立记录 |
+
+---
+
+## 三、实施计划
+
+> **使用 Skill**: `executing-plans` + `test-driven-development`
+> **TDD 原则**: 红色测试 → 绿色实现 → 重构优化
+
+### Phase 1: 关键业务逻辑修复（必须）
+
+#### 1.1 混合资产类别查询检测
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_determine_dataset()` 方法
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): detect and reject mixed asset class queries`
+- **状态**: [ ] 未完成
+
+```python
+# 在 _determine_dataset 中添加混合检测
+if has_stock and has_etf:
+    raise ValueError("Mixed asset class query detected...")
+```
+
+#### 1.2 QFQ 前复权因子排序（存储层）
+- **文件**: `packages/datahub/src/ditto_datahub/stores/adj_factor_store.py`
+- **修改**: `_write_impl()` 排序逻辑
+- **测试**: `packages/datahub/tests/test_adj_factor_store.py`
+- **Commit**: `fix(adj_factor_store): ensure sid, trade_date sorting on write`
+- **状态**: [ ] 未完成
+
+```python
+# 添加 sid 到排序键
+combined = combined.sort(["sid", "trade_date"])
+```
+
+#### 1.3 QFQ 前复权因子排序（查询层）
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_apply_adj()` 方法
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): sort adj_df before last() aggregation`
+- **状态**: [ ] 未完成
+
+```python
+adj_df = adj_df.sort(["sid", "trade_date"])
+```
+
+#### 1.4 复权因子缺失处理（QFQ）
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_apply_adj()` QFQ 分支
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): use coalesce for missing adj_factor in QFQ`
+- **状态**: [ ] 未完成
+
+```python
+pl.col("open") * pl.coalesce("latest_factor", 1.0) / pl.coalesce("adj_factor", 1.0)
+```
+
+#### 1.5 复权因子缺失处理（HFQ）
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_apply_adj()` HFQ 分支
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): use coalesce for missing adj_factor in HFQ`
+- **状态**: [ ] 未完成
+
+```python
+pl.col("open") * pl.coalesce("adj_factor", 1.0)
+```
+
+---
+
+### Phase 2: 数据安全修复（必须）
+
+#### 2.1 SQLite 外键启用
+- **文件**: `packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py`
+- **修改**: `get_connection()` 方法
+- **测试**: `packages/datahub/tests/unit/runtime/test_sqlite_pool.py` (新建)
+- **Commit**: `fix(sqlite_pool): enable foreign key constraints`
+- **状态**: [ ] 未完成
+
+```python
+conn.execute("PRAGMA foreign_keys = ON;")
+```
+
+#### 2.2 SQL 注入风险修复
+- **文件**: `packages/datahub/src/ditto_datahub/stores/security_store.py`
+- **修改**: 创建 `_build_in_clause()` 辅助函数
+- **测试**: `packages/datahub/tests/unit/stores/test_security_store.py`
+- **Commit**: `fix(security_store): refactor IN clause with helper function`
+- **状态**: [ ] 未完成
+
+#### 2.3 AdjFactorStore 日期规范化
+- **文件**: `packages/datahub/src/ditto_datahub/stores/adj_factor_store.py`
+- **修改**: `_write_impl()` 添加日期类型检查
+- **测试**: `packages/datahub/tests/test_adj_factor_store.py`
+- **Commit**: `fix(adj_factor_store): normalize trade_date type on write`
+- **状态**: [ ] 未完成
+
+---
+
+### Phase 3: 代码质量提升（推荐）
+
+#### 3.1 拆分 _write_impl 函数
+- **文件**: `packages/datahub/src/ditto_datahub/stores/bars_store.py`
+- **修改**: 提取 `_ensure_dataset_dir()`, `_merge_with_existing()`, `_prepare_for_write()`
+- **测试**: 现有测试应继续通过
+- **Commit**: `refactor(bars_store): extract helper methods from _write_impl`
+- **状态**: [ ] 未完成
+
+#### 3.2 添加 BarsStore 输入验证
+- **文件**: `packages/datahub/src/ditto_datahub/stores/bars_store.py`
+- **修改**: 添加 `_validate_bars_schema()` 函数
+- **测试**: `packages/datahub/tests/unit/stores/test_bars_store.py`
+- **Commit**: `feat(bars_store): add DataFrame schema validation`
+- **状态**: [ ] 未完成
+
+#### 3.3 添加 AdjFactorStore 输入验证
+- **文件**: `packages/datahub/src/ditto_datahub/stores/adj_factor_store.py`
+- **修改**: 添加 `_validate_adj_factor_schema()` 函数
+- **测试**: `packages/datahub/tests/test_adj_factor_store.py`
+- **Commit**: `feat(adj_factor_store): add DataFrame schema validation`
+- **状态**: [ ] 未完成
+
+#### 3.4 移除冗余类型断言
+- **文件**: `packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py`
+- **修改**: 移除 `assert isinstance(...)` 行
+- **测试**: 现有测试应继续通过
+- **Commit**: `refactor(sqlite_pool): remove redundant type assertion`
+- **状态**: [ ] 未完成
+
+---
+
+### Phase 4: 代码风格改进（可选）
+
+#### 4.1 symbol 多重匹配警告
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `get_single()` 添加警告日志
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `feat(bars): add warning for ambiguous symbol resolution`
+- **状态**: [ ] 未完成
+
+#### 4.2 统一 DataFrame 类型注解
+- **文件**: 多个 Store 文件
+- **修改**: 统一使用 `pl.DataFrame`
+- **测试**: 无需测试
+- **Commit**: `style(datahub): standardize DataFrame type annotations`
+- **状态**: [ ] 未完成
+
+#### 4.3 增强日期参数灵活性
+- **文件**: 多个 read() 方法
+- **修改**: 添加 `_normalize_date()` 辅助函数
+- **测试**: 相关测试
+- **Commit**: `feat(datahub): support datetime objects in date parameters`
+- **状态**: [ ] 未完成
+
+---
+
+## 四、Git 提交策略
+
+### 提交粒度原则
+- ✅ 每个 TDD 循环独立提交（RED → GREEN → REFACTOR）
+- ✅ 完成一个独立功能点立即提交
+- ❌ 不将多个不相关改动混在一个提交
+
+### 预期提交序列
+
+```bash
+# Phase 1: 业务逻辑修复
+git commit -m "test(bars): add test for mixed asset class detection"
+git commit -m "fix(bars): detect and reject mixed asset class queries"
+
+git commit -m "test(adj_factor_store): add test for sorting behavior"
+git commit -m "fix(adj_factor_store): ensure sid, trade_date sorting on write"
+
+git commit -m "test(bars): add test for unsorted adj_factor handling"
+git commit -m "fix(bars): sort adj_df before last() aggregation"
+
+git commit -m "test(bars): add test for missing adj_factor in QFQ"
+git commit -m "fix(bars): use coalesce for missing adj_factor in QFQ"
+
+git commit -m "test(bars): add test for missing adj_factor in HFQ"
+git commit -m "fix(bars): use coalesce for missing adj_factor in HFQ"
+
+# Phase 2: 数据安全修复
+git commit -m "test(sqlite_pool): add test for foreign key enforcement"
+git commit -m "fix(sqlite_pool): enable foreign key constraints"
+
+git commit -m "test(security_store): add test for IN clause safety"
+git commit -m "fix(security_store): refactor IN clause with helper function"
+
+git commit -m "test(adj_factor_store): add test for date normalization"
+git commit -m "fix(adj_factor_store): normalize trade_date type on write"
+
+# Phase 3: 代码质量
+git commit -m "refactor(bars_store): extract helper methods from _write_impl"
+git commit -m "feat(bars_store): add DataFrame schema validation"
+git commit -m "feat(adj_factor_store): add DataFrame schema validation"
+git commit -m "refactor(sqlite_pool): remove redundant type assertion"
+
+# Phase 4: 风格改进（可选）
+git commit -m "feat(bars): add warning for ambiguous symbol resolution"
+# ...
+```
+
+---
+
+## 五、验收标准
+
+### 功能
+- [ ] 混合资产查询抛出 ValueError
+- [ ] QFQ 复权在任何情况下使用正确的最新因子
+- [ ] 复权因子缺失时返回原始价格
+- [ ] SQLite 外键约束生效
+- [ ] SQL IN 子句使用参数化查询
+- [ ] 日期输入自动规范化
+
+### 质量
+- [ ] 所有新测试通过
+- [ ] 现有测试不被破坏
+- [ ] `pixi run -e dev ci-check` 全部通过
+- [ ] 覆盖率保持 ≥80%
+
+### 性能
+- [ ] 排序操作不影响读取性能（需验证）
+
+---
+
+## 六、文件清单
+
+### 需要修改的文件
+
+```
+packages/datahub/src/ditto_datahub/
+├── repositories/
+│   └── bars.py                    # 混合资产检测、QFQ 排序、null 处理、symbol 警告
+├── stores/
+│   ├── adj_factor_store.py        # 存储排序、日期规范化
+│   ├── bars_store.py              # 函数拆分、输入验证
+│   └── security_store.py          # SQL IN 子句重构
+└── runtime/
+    └── sqlite_pool.py             # 外键启用、移除断言
+```
+
+### 需要添加测试的文件
+
+```
+packages/datahub/tests/
+├── unit/
+│   ├── repositories/
+│   │   └── test_bars_repository.py    # 混合资产、复权缺失、排序测试
+│   ├── stores/
+│   │   ├── test_bars_store.py         # 输入验证测试
+│   │   └── test_security_store.py     # SQL 安全测试
+│   └── runtime/
+│       └── test_sqlite_pool.py        # 外键约束测试（新建）
+└── test_adj_factor_store.py           # 日期规范化测试
+```
+
+---
+
+## 七、完成阶段
+
+> **使用 Skill**: `finishing-a-development-branch`
+
+### 7.1 完成前验证
+- [ ] `pixi run -e dev ci-check` 全部通过
+- [ ] 所有新测试通过
+- [ ] 所有现有测试不被破坏
+- [ ] 代码已 Polishing
+- [ ] DoD 全部勾选
+
+### 7.2 决策点
+- [ ] 创建 PR → 继续下一步
+- [ ] 本地合并 → 不适用（多文件修改）
+- [ ] 保留分支 → 如需进一步调整
+- [ ] 丢弃分支 → 不适用
+
+### 7.3 创建 PR
+```bash
+git push -u origin fix/datahub-code-quality
+gh pr create --base main --title "fix(datahub): code quality fixes and data safety improvements"
+```
+
+---
+
+## 八、完成总结
+
+<!-- 任务完成后填写 -->
+
+### 已实现
+- [ ] Phase 1: 业务逻辑修复
+- [ ] Phase 2: 数据安全修复
+- [ ] Phase 3: 代码质量提升
+- [ ] Phase 4: 风格改进
+
+### 遗留问题
+- [ ] ...
+
+### 经验教训
+- [ ] ...
+
+---
+
+**最后更新**: 2025-12-26

--- a/packages/datahub/src/ditto_datahub/errors.py
+++ b/packages/datahub/src/ditto_datahub/errors.py
@@ -89,3 +89,51 @@ class ValidationError(DataHubError):
     """DataFrame schema validation failed."""
 
     pass
+
+
+class DatasetNotFoundError(DataHubError):
+    """Dataset directory or files do not exist."""
+
+    def __init__(
+        self,
+        message: str = "Dataset not found",
+        dataset: str | None = None,
+    ) -> None:
+        """
+        Initialize DatasetNotFoundError.
+
+        Args:
+            message: Error message.
+            dataset: The dataset name that was not found.
+
+        """
+        details: dict[str, object] = {}
+        if dataset:
+            details["dataset"] = dataset
+        super().__init__(message, details if details else None)
+
+
+class PartitionNotFoundError(DataHubError):
+    """Year partition file does not exist."""
+
+    def __init__(
+        self,
+        message: str = "Partition not found",
+        dataset: str | None = None,
+        year: int | None = None,
+    ) -> None:
+        """
+        Initialize PartitionNotFoundError.
+
+        Args:
+            message: Error message.
+            dataset: The dataset name.
+            year: The year partition that was not found.
+
+        """
+        details: dict[str, object] = {}
+        if dataset:
+            details["dataset"] = dataset
+        if year:
+            details["year"] = year
+        super().__init__(message, details if details else None)

--- a/packages/datahub/src/ditto_datahub/errors.py
+++ b/packages/datahub/src/ditto_datahub/errors.py
@@ -83,3 +83,9 @@ class TradingDateNotFoundError(CalendarError):
         if direction:
             details["direction"] = direction
         super().__init__(message, details if details else None)
+
+
+class ValidationError(DataHubError):
+    """DataFrame schema validation failed."""
+
+    pass

--- a/packages/datahub/src/ditto_datahub/meta/README.md
+++ b/packages/datahub/src/ditto_datahub/meta/README.md
@@ -11,6 +11,7 @@
 | 文件 | 功能 |
 |------|------|
 | `schemas.py` | Polars Schema 定义 |
+| `schema_validator.py` | Schema 验证工具 |
 
 ## 三、定义的 Schema
 

--- a/packages/datahub/src/ditto_datahub/meta/schema_validator.py
+++ b/packages/datahub/src/ditto_datahub/meta/schema_validator.py
@@ -1,0 +1,155 @@
+"""
+DataFrame schema validation module.
+
+Validates Polars DataFrames against predefined schemas for datasets.
+"""
+
+import polars as pl
+
+from ditto_datahub.errors import ValidationError
+from ditto_datahub.meta.schemas import (
+    ADJ_FACTOR_SCHEMA,
+    ETF_DAILY_SCHEMA,
+    INDEX_DAILY_SCHEMA,
+    INDEX_WEIGHT_SCHEMA,
+    STOCK_DAILY_SCHEMA,
+    UNIVERSE_CONSTITUENT_SCHEMA,
+)
+
+# Dataset schema mapping
+DATASET_SCHEMAS: dict[str, dict[str, type[pl.DataType]]] = {
+    "stock_daily": STOCK_DAILY_SCHEMA,
+    "market_daily": STOCK_DAILY_SCHEMA,  # Alias for backwards compatibility
+    "etf_daily": ETF_DAILY_SCHEMA,
+    "index_daily": INDEX_DAILY_SCHEMA,
+    "adj_factor": ADJ_FACTOR_SCHEMA,
+    "index_weight": INDEX_WEIGHT_SCHEMA,
+    "universe_constituent": UNIVERSE_CONSTITUENT_SCHEMA,
+}
+
+
+def validate_dataframe_schema(df: pl.DataFrame, dataset: str) -> None:
+    """
+    Validate DataFrame against schema definition.
+
+    Args:
+        df: DataFrame to validate.
+        dataset: Dataset name (e.g., "stock_daily", "adj_factor").
+
+    Raises:
+        ValidationError: If DataFrame doesn't match schema.
+
+    """
+    # Skip validation for unknown datasets
+    if dataset not in DATASET_SCHEMAS:
+        return
+
+    schema = DATASET_SCHEMAS[dataset]
+
+    # Check required columns
+    _validate_required_columns(df, schema)
+
+    # Check column types
+    _validate_column_types(df, schema, dataset)
+
+
+def _validate_required_columns(
+    df: pl.DataFrame, schema: dict[str, type[pl.DataType]]
+) -> None:
+    """
+    Validate that all required columns are present.
+
+    Args:
+        df: DataFrame to validate.
+        schema: Schema definition.
+
+    Raises:
+        ValidationError: If required columns are missing.
+
+    """
+    required_columns = set(schema.keys())
+    actual_columns = set(df.columns)
+
+    missing = required_columns - actual_columns
+    if missing:
+        raise ValidationError(
+            f"Missing required columns: {sorted(missing)}",
+            details={
+                "missing_columns": sorted(missing),
+                "expected": sorted(required_columns),
+            },
+        )
+
+
+def _validate_column_types(
+    df: pl.DataFrame, schema: dict[str, type[pl.DataType]], dataset: str
+) -> None:
+    """
+    Validate that columns have correct data types.
+
+    Args:
+        df: DataFrame to validate.
+        schema: Schema definition.
+        dataset: Dataset name (for error messages).
+
+    Raises:
+        ValidationError: If columns have wrong types.
+
+    """
+    for col_name, expected_type_base in schema.items():
+        if col_name not in df.columns:
+            continue  # Already checked in _validate_required_columns
+
+        actual_type = df[col_name].dtype
+
+        # Normalize types for comparison
+        # pl.Utf8 == pl.String (they're the same)
+        normalized_expected = (
+            pl.String if expected_type_base == pl.Utf8 else expected_type_base
+        )
+
+        # Check type compatibility (compare base types by name)
+        if not _is_type_compatible(actual_type, normalized_expected):
+            msg = (
+                f"Column '{col_name}' has wrong type: "
+                f"expected {normalized_expected}, got {actual_type}"
+            )
+            raise ValidationError(
+                msg,
+                details={
+                    "column": col_name,
+                    "expected_type": str(normalized_expected),
+                    "actual_type": str(actual_type),
+                    "dataset": dataset,
+                },
+            )
+
+
+def _is_type_compatible(
+    actual: pl.DataType, expected_type_base: type[pl.DataType]
+) -> bool:
+    """
+    Check if actual Polars type is compatible with expected type.
+
+    Args:
+        actual: Actual data type.
+        expected_type_base: Expected data type class.
+
+    Returns:
+        True if types are compatible.
+
+    """
+    # Direct match - compare base type names
+    actual_base = type(actual)
+    if actual_base == expected_type_base:
+        return True
+
+    # Null types are compatible with any type (nullable columns)
+    if isinstance(actual, pl.Null):
+        return True
+
+    # Categorical can be compatible with String/Utf8
+    return bool(
+        isinstance(actual, pl.Categorical)
+        and expected_type_base in (pl.String, pl.Utf8)
+    )

--- a/packages/datahub/src/ditto_datahub/repositories/bars.py
+++ b/packages/datahub/src/ditto_datahub/repositories/bars.py
@@ -316,15 +316,25 @@ class BarsRepository:
         if asset_class:
             return f"{asset_class}_daily"
 
-        # Determine by SID range
+        # Check for mixed asset classes
         stock_range = SidRange.get_range("stock")
         etf_range = SidRange.get_range("etf")
 
-        for sid in sids:
-            if stock_range.min_sid <= sid <= stock_range.max_sid:
-                return "stock_daily"
-            if etf_range.min_sid <= sid <= etf_range.max_sid:
-                return "etf_daily"
+        has_stock = any(
+            stock_range.min_sid <= sid <= stock_range.max_sid for sid in sids
+        )
+        has_etf = any(etf_range.min_sid <= sid <= etf_range.max_sid for sid in sids)
+
+        if has_stock and has_etf:
+            raise ValueError(
+                "Mixed asset class query detected. SIDs contain both stock and ETF. "
+                "Please query each asset class separately."
+            )
+
+        if has_stock:
+            return "stock_daily"
+        if has_etf:
+            return "etf_daily"
 
         return "stock_daily"  # Default
 

--- a/packages/datahub/src/ditto_datahub/repositories/bars.py
+++ b/packages/datahub/src/ditto_datahub/repositories/bars.py
@@ -12,7 +12,7 @@ from ditto_foundation import M, logger, traced
 from ditto_datahub.stores.adj_factor_store import AdjFactorStore
 from ditto_datahub.stores.bars_store import BarsStore
 from ditto_datahub.stores.security_store import SecurityStore
-from ditto_datahub.types import SidRange
+from ditto_datahub.types import DQResult, SidRange
 
 if TYPE_CHECKING:
     from ditto_datahub.runtime.dq_checker import DQChecker
@@ -35,7 +35,7 @@ class WriteResult:
     checksum: str
     rows_written: int
     rows_total: int
-    failed_checks: list[Any] = field(default_factory=list)
+    failed_checks: list[DQResult] = field(default_factory=list)
 
 
 class BarsRepository:

--- a/packages/datahub/src/ditto_datahub/repositories/bars.py
+++ b/packages/datahub/src/ditto_datahub/repositories/bars.py
@@ -184,6 +184,18 @@ class BarsRepository:
             sids = self._security_store.resolve_by_symbol(identifier, source)
             if not sids:
                 return pl.DataFrame()
+
+            # Warn if multiple SIDs match the same symbol
+            if len(sids) > 1:
+                logger.warning(
+                    "Multiple SIDs found for symbol, using first match",
+                    event="symbol_multiple_matches",
+                    symbol=identifier,
+                    sids=sids,
+                    selected_sid=sids[0],
+                    match_count=len(sids),
+                )
+
             sid = sids[0]
 
         # Get data

--- a/packages/datahub/src/ditto_datahub/repositories/bars.py
+++ b/packages/datahub/src/ditto_datahub/repositories/bars.py
@@ -363,6 +363,9 @@ class BarsRepository:
             )
             return df
 
+        # Ensure sorting for correct last() aggregation (defensive programming)
+        adj_df = adj_df.sort(["sid", "trade_date"])
+
         # Join adjustment factors
         df = df.join(
             adj_df.select(["sid", "trade_date", "adj_factor"]),

--- a/packages/datahub/src/ditto_datahub/repositories/bars.py
+++ b/packages/datahub/src/ditto_datahub/repositories/bars.py
@@ -379,19 +379,28 @@ class BarsRepository:
                 pl.col("adj_factor").last().alias("latest_factor")
             )
             df = df.join(latest_factors, on="sid", how="left")
+            # Use coalesce(adj_factor, 1.0) for missing values (returns original price)
             df = df.with_columns(
                 [
                     (
-                        pl.col("open") * pl.col("latest_factor") / pl.col("adj_factor")
+                        pl.col("open")
+                        * pl.coalesce("latest_factor", 1.0)
+                        / pl.coalesce("adj_factor", 1.0)
                     ).alias("open"),
                     (
-                        pl.col("high") * pl.col("latest_factor") / pl.col("adj_factor")
+                        pl.col("high")
+                        * pl.coalesce("latest_factor", 1.0)
+                        / pl.coalesce("adj_factor", 1.0)
                     ).alias("high"),
                     (
-                        pl.col("low") * pl.col("latest_factor") / pl.col("adj_factor")
+                        pl.col("low")
+                        * pl.coalesce("latest_factor", 1.0)
+                        / pl.coalesce("adj_factor", 1.0)
                     ).alias("low"),
                     (
-                        pl.col("close") * pl.col("latest_factor") / pl.col("adj_factor")
+                        pl.col("close")
+                        * pl.coalesce("latest_factor", 1.0)
+                        / pl.coalesce("adj_factor", 1.0)
                     ).alias("close"),
                 ]
             )
@@ -399,12 +408,13 @@ class BarsRepository:
 
         else:  # HFQ
             # Backward adjustment: use current factor
+            # Use coalesce(adj_factor, 1.0) for missing values (returns original price)
             df = df.with_columns(
                 [
-                    (pl.col("open") * pl.col("adj_factor")).alias("open"),
-                    (pl.col("high") * pl.col("adj_factor")).alias("high"),
-                    (pl.col("low") * pl.col("adj_factor")).alias("low"),
-                    (pl.col("close") * pl.col("adj_factor")).alias("close"),
+                    (pl.col("open") * pl.coalesce("adj_factor", 1.0)).alias("open"),
+                    (pl.col("high") * pl.coalesce("adj_factor", 1.0)).alias("high"),
+                    (pl.col("low") * pl.coalesce("adj_factor", 1.0)).alias("low"),
+                    (pl.col("close") * pl.coalesce("adj_factor", 1.0)).alias("close"),
                 ]
             )
             df = df.drop("adj_factor")

--- a/packages/datahub/src/ditto_datahub/runtime/README.md
+++ b/packages/datahub/src/ditto_datahub/runtime/README.md
@@ -15,6 +15,7 @@
 | `file_lock.py` | 跨平台文件锁，防止并发写入冲突 |
 | `dq_checker.py` | 数据质量检查引擎 |
 | `dq_rules.py` | DQ 规则定义 (主键、OHLC、涨跌停等) |
+| `sql_engine.py` | SQL 引擎，提供跨数据库查询能力 |
 
 ## 三、使用示例
 

--- a/packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py
+++ b/packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py
@@ -3,7 +3,7 @@
 import sqlite3
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from ditto_foundation import logger
 
@@ -29,6 +29,8 @@ class SQLitePool:
                 str(self._db_path), check_same_thread=False, timeout=30.0
             )
             conn.row_factory = sqlite3.Row
+            # Enable foreign key constraints
+            conn.execute("PRAGMA foreign_keys = ON;")
             self._local.conn = conn
 
             logger.debug(
@@ -36,10 +38,7 @@ class SQLitePool:
                 event="connection_created",
                 thread_id=threading.get_ident(),
             )
-        # Add runtime type check to help mypy understand the type
-        conn = self._local.conn
-        assert isinstance(conn, sqlite3.Connection), "conn must be sqlite3.Connection"
-        return conn
+        return cast(sqlite3.Connection, self._local.conn)
 
     def _get_connection(self) -> sqlite3.Connection:
         """Get thread-local connection (deprecated, use get_connection)."""

--- a/packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py
+++ b/packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py
@@ -3,7 +3,7 @@
 import sqlite3
 import threading
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from ditto_foundation import logger
 
@@ -38,7 +38,8 @@ class SQLitePool:
                 event="connection_created",
                 thread_id=threading.get_ident(),
             )
-        return cast(sqlite3.Connection, self._local.conn)
+        # Type is correctly inferred but mypy sees Any from threading.local
+        return self._local.conn  # type: ignore[no-any-return]
 
     def _get_connection(self) -> sqlite3.Connection:
         """Get thread-local connection (deprecated, use get_connection)."""

--- a/packages/datahub/src/ditto_datahub/stores/adj_factor_store.py
+++ b/packages/datahub/src/ditto_datahub/stores/adj_factor_store.py
@@ -141,7 +141,13 @@ class AdjFactorStore:
             end_dt = datetime.strptime(end_date, "%Y-%m-%d").date()
             lf = lf.filter(pl.col("trade_date") <= pl.lit(end_dt))
 
-        result = lf.unique(subset=["sid", "trade_date"], keep="last").collect()
+        # Ensure sorting for correct unique(keep="last") and result order
+        result = (
+            lf.sort(["sid", "trade_date"])
+            .unique(subset=["sid", "trade_date"], keep="last")
+            .sort(["sid", "trade_date"])  # Ensure result is sorted
+            .collect()
+        )
 
         duration_ms = (time.time() - start_time) * 1000
 
@@ -212,8 +218,8 @@ class AdjFactorStore:
         else:
             combined = df
 
-        # Sort for optimal read performance
-        combined = combined.sort(["trade_date", "sid"])
+        # Sort for optimal read performance AND correct last() aggregation
+        combined = combined.sort(["sid", "trade_date"])
 
         # Atomic write
         atomic_write(combined, file_path)

--- a/packages/datahub/src/ditto_datahub/stores/adj_factor_store.py
+++ b/packages/datahub/src/ditto_datahub/stores/adj_factor_store.py
@@ -218,6 +218,15 @@ class AdjFactorStore:
         else:
             combined = df
 
+        # Normalize trade_date to Date type if needed
+        if "trade_date" in combined.columns:
+            if combined["trade_date"].dtype == pl.String:
+                combined = combined.with_columns(
+                    pl.col("trade_date").str.strptime(pl.Date, "%Y-%m-%d")
+                )
+            elif combined["trade_date"].dtype != pl.Date:
+                combined = combined.with_columns(pl.col("trade_date").cast(pl.Date))
+
         # Sort for optimal read performance AND correct last() aggregation
         combined = combined.sort(["sid", "trade_date"])
 

--- a/packages/datahub/src/ditto_datahub/stores/bars_store.py
+++ b/packages/datahub/src/ditto_datahub/stores/bars_store.py
@@ -121,6 +121,60 @@ class BarsStore:
 
         return df
 
+    def _ensure_dataset_dir(self, dataset: str) -> Path:
+        """
+        Ensure dataset directory exists.
+
+        Args:
+            dataset: Dataset name.
+
+        Returns:
+            Path to the dataset directory.
+
+        """
+        dataset_dir = self._data_root / dataset
+        dataset_dir.mkdir(parents=True, exist_ok=True)
+        return dataset_dir
+
+    def _merge_with_existing(self, df: pl.DataFrame, file_path: Path) -> pl.DataFrame:
+        """
+        Merge DataFrame with existing data if file exists.
+
+        Args:
+            df: New data to write.
+            file_path: Path to existing data file.
+
+        Returns:
+            Merged DataFrame with unique sid/date pairs.
+
+        """
+        if file_path.exists():
+            existing = pl.read_parquet(file_path)
+            combined = pl.concat([existing, df])
+            combined = combined.unique(
+                subset=["sid", "trade_date"],
+                keep="last",
+            )
+        else:
+            combined = df
+        return combined
+
+    def _prepare_for_write(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Prepare DataFrame for writing: normalize dates and sort.
+
+        Args:
+            df: Input DataFrame.
+
+        Returns:
+            Prepared DataFrame with Date type and sorted.
+
+        """
+        # Ensure trade_date is date type for sorting
+        df = self._ensure_date_column(df)
+        # Sort for optimal read performance
+        return df.sort(["trade_date", "sid"])
+
     # ============ Read operations ============
 
     @traced("data.read")
@@ -233,28 +287,15 @@ class BarsStore:
     ) -> tuple[str, str]:
         start_time = time.time()
 
-        dataset_dir = self._data_root / dataset
-        dataset_dir.mkdir(parents=True, exist_ok=True)
+        # Ensure dataset directory exists
+        self._ensure_dataset_dir(dataset)
 
         file_path = self._get_path(dataset, year)
         is_merge = file_path.exists()
 
-        # Merge with existing data
-        if file_path.exists():
-            existing = pl.read_parquet(file_path)
-            combined = pl.concat([existing, df])
-            combined = combined.unique(
-                subset=["sid", "trade_date"],
-                keep="last",
-            )
-        else:
-            combined = df
-
-        # Ensure trade_date is date type for sorting
-        combined = self._ensure_date_column(combined)
-
-        # Sort for optimal read performance
-        combined = combined.sort(["trade_date", "sid"])
+        # Merge with existing data and prepare for write
+        combined = self._merge_with_existing(df, file_path)
+        combined = self._prepare_for_write(combined)
 
         # Atomic write
         atomic_write(combined, file_path)

--- a/packages/datahub/src/ditto_datahub/stores/security_store.py
+++ b/packages/datahub/src/ditto_datahub/stores/security_store.py
@@ -18,6 +18,30 @@ from ditto_foundation import M, logger, span, traced
 from ditto_datahub.stores.sqlite_client import SQLiteClient
 
 
+def _build_in_clause(items: list[Any]) -> tuple[str, list[Any]]:
+    """
+    Build parameterized IN clause with placeholders.
+
+    This helper function ensures SQL injection safety by using
+    parameterized queries for IN clauses.
+
+    Args:
+        items: List of values for the IN clause.
+
+    Returns:
+        Tuple of (SQL fragment with placeholders, list of values).
+
+    Example:
+        >>> _build_in_clause([1, 2, 3])
+        ('(?,?,?)', [1, 2, 3])
+
+    """
+    if not items:
+        return ("()", [])
+    placeholders = ",".join("?" * len(items))
+    return f"({placeholders})", items
+
+
 class SecurityStore:
     """
     Securities master data storage with PIT support.
@@ -292,14 +316,14 @@ class SecurityStore:
         params: list[Any] = []
 
         if sids:
-            placeholders = ",".join("?" * len(sids))
-            sql += f" AND s.sid IN ({placeholders})"
-            params.extend(sids)
+            in_clause, sids_list = _build_in_clause(sids)
+            sql += f" AND s.sid IN {in_clause}"
+            params.extend(sids_list)
 
         if src_codes:
-            placeholders = ",".join("?" * len(src_codes))
-            sql += f" AND m.src_code IN ({placeholders}) AND m.source = ?"
-            params.extend(src_codes)
+            in_clause, src_codes_list = _build_in_clause(src_codes)
+            sql += f" AND m.src_code IN {in_clause} AND m.source = ?"
+            params.extend(src_codes_list)
             params.append(source)
 
             if asof:
@@ -392,10 +416,10 @@ class SecurityStore:
 
         """
         if sids:
-            placeholders = ",".join("?" * len(sids))
+            in_clause, sids_list = _build_in_clause(sids)
             rows = self._client.fetchall(
-                f"SELECT sid, symbol FROM security WHERE sid IN ({placeholders})",  # nosec
-                sids,
+                f"SELECT sid, symbol FROM security WHERE sid IN {in_clause}",
+                sids_list,
             )
         else:
             rows = self._client.fetchall(

--- a/packages/datahub/src/ditto_datahub/stores/sqlite_client.py
+++ b/packages/datahub/src/ditto_datahub/stores/sqlite_client.py
@@ -21,6 +21,8 @@ class SQLiteClient:
     # Allowed table names for count() method (security whitelist)
     ALLOWED_TABLES = frozenset(
         [
+            "sid_sequence",
+            "price_limit_config",
             "security",
             "security_mapping",
             "trading_calendar",

--- a/packages/datahub/src/ditto_datahub/stores/sqlite_client.py
+++ b/packages/datahub/src/ditto_datahub/stores/sqlite_client.py
@@ -173,7 +173,7 @@ class SQLiteClient:
 
     def fetchval(
         self, sql: str, params: list[Any] | tuple[Any, ...] | None = None
-    ) -> Any:
+    ) -> str | int | float | None:
         """
         Query single value.
 
@@ -182,13 +182,14 @@ class SQLiteClient:
             params: Parameter list.
 
         Returns:
-            First row first column value, or None.
+            First row first column value (str, int, float, or None).
 
         """
         cursor = self.execute(sql, params)
         row = cursor.fetchone()
         if row:
-            return row[0]
+            # mypy can't infer the type from sqlite3.Row, use cast
+            return cast(str | int | float, row[0])
         return None
 
     def commit(self) -> None:
@@ -273,4 +274,6 @@ class SQLiteClient:
         if where:
             sql += f" WHERE {where}"
 
-        return self.fetchval(sql, params) or 0
+        result = self.fetchval(sql, params)
+        # COUNT(*) always returns int, but mypy can't infer that
+        return int(result) if result is not None else 0

--- a/packages/datahub/src/ditto_datahub/utils/dates.py
+++ b/packages/datahub/src/ditto_datahub/utils/dates.py
@@ -1,0 +1,47 @@
+"""
+Date normalization utilities for DataHub.
+
+Provides functions to normalize various date input types (str, date, datetime)
+to a consistent string format (YYYY-MM-DD) used throughout DataHub.
+"""
+
+from datetime import date, datetime
+
+# Type alias for date inputs accepted by DataHub APIs
+DateInput = str | date | datetime | None
+
+
+def normalize_date(value: DateInput) -> str | None:
+    """
+    Normalize various date input types to YYYY-MM-DD string format.
+
+    Args:
+        value: Date input (str, date, datetime, or None).
+
+    Returns:
+        Normalized date string in YYYY-MM-DD format, or None if input is None.
+
+    Raises:
+        ValueError: If string is not in valid YYYY-MM-DD format.
+
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        # Validate string format by attempting to parse it
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+            return value
+        except ValueError as e:
+            raise ValueError(f"Invalid date format: {value}") from e
+
+    if isinstance(value, datetime):
+        # Convert datetime to date, then format
+        return value.strftime("%Y-%m-%d")
+
+    if isinstance(value, date):
+        # Format date object
+        return value.strftime("%Y-%m-%d")
+
+    raise TypeError(f"Unsupported date type: {type(value)}")

--- a/packages/datahub/src/ditto_datahub/utils/dates.py
+++ b/packages/datahub/src/ditto_datahub/utils/dates.py
@@ -1,47 +1,11 @@
 """
-Date normalization utilities for DataHub.
+Re-export date normalization utilities from foundation.
 
-Provides functions to normalize various date input types (str, date, datetime)
-to a consistent string format (YYYY-MM-DD) used throughout DataHub.
+This module re-exports DateInput and normalize_date from ditto_foundation.util.dates
+for backward compatibility.
 """
 
-from datetime import date, datetime
+# Re-export from foundation for backward compatibility
+from ditto_foundation.util.dates import DateInput, normalize_date
 
-# Type alias for date inputs accepted by DataHub APIs
-DateInput = str | date | datetime | None
-
-
-def normalize_date(value: DateInput) -> str | None:
-    """
-    Normalize various date input types to YYYY-MM-DD string format.
-
-    Args:
-        value: Date input (str, date, datetime, or None).
-
-    Returns:
-        Normalized date string in YYYY-MM-DD format, or None if input is None.
-
-    Raises:
-        ValueError: If string is not in valid YYYY-MM-DD format.
-
-    """
-    if value is None:
-        return None
-
-    if isinstance(value, str):
-        # Validate string format by attempting to parse it
-        try:
-            datetime.strptime(value, "%Y-%m-%d")
-            return value
-        except ValueError as e:
-            raise ValueError(f"Invalid date format: {value}") from e
-
-    if isinstance(value, datetime):
-        # Convert datetime to date, then format
-        return value.strftime("%Y-%m-%d")
-
-    if isinstance(value, date):
-        # Format date object
-        return value.strftime("%Y-%m-%d")
-
-    raise TypeError(f"Unsupported date type: {type(value)}")
+__all__ = ["DateInput", "normalize_date"]

--- a/packages/datahub/tests/test_adj_factor_store.py
+++ b/packages/datahub/tests/test_adj_factor_store.py
@@ -320,3 +320,42 @@ class TestAdjFactorStore:
         store.write("adj_factor", sample_df, 2024)
         sids = store.list_sids("adj_factor")
         assert sids == [100000001, 100000002]
+
+    def test_write_maintains_sid_and_date_sorting(
+        self, store: AdjFactorStore, tmp_path: Path
+    ) -> None:
+        """Test that write ensures data is sorted by sid and trade_date."""
+        # Arrange: Create intentionally unsorted data
+        unsorted_df = pl.DataFrame(
+            {
+                "sid": [100000002, 100000001, 100000002, 100000001],
+                "trade_date": [
+                    date(2024, 1, 5),
+                    date(2024, 1, 2),
+                    date(2024, 1, 3),
+                    date(2024, 1, 4),
+                ],
+                "adj_factor": [1.0, 1.0, 0.95, 1.0],
+            }
+        )
+
+        # Act: Write the data
+        store.write("adj_factor", unsorted_df, 2024)
+
+        # Assert: Read back and verify it's sorted by (sid, trade_date)
+        result = store.read("adj_factor")
+
+        # Check that rows are in the correct order
+        for i in range(len(result) - 1):
+            current_sid = result["sid"][i]
+            next_sid = result["sid"][i + 1]
+            current_date = result["trade_date"][i]
+            next_date = result["trade_date"][i + 1]
+
+            # Either current sid < next sid, or same sid with current date <= next date
+            assert current_sid < next_sid or (
+                current_sid == next_sid and current_date <= next_date
+            ), (
+                f"Row {i} not sorted: ({current_sid}, {current_date}) "
+                f"before ({next_sid}, {next_date})"
+            )

--- a/packages/datahub/tests/test_adj_factor_store.py
+++ b/packages/datahub/tests/test_adj_factor_store.py
@@ -359,3 +359,72 @@ class TestAdjFactorStore:
                 f"Row {i} not sorted: ({current_sid}, {current_date}) "
                 f"before ({next_sid}, {next_date})"
             )
+
+
+class TestDateNormalization:
+    """Tests for date type normalization in write."""
+
+    @pytest.fixture
+    def data_root(self, tmp_path: Path) -> Path:
+        """Create temporary data root directory."""
+        return tmp_path / "data"
+
+    @pytest.fixture
+    def store(self, data_root: Path) -> AdjFactorStore:
+        """Create AdjFactorStore instance."""
+        return AdjFactorStore(data_root)
+
+    def test_write_with_string_trade_date(self, store: AdjFactorStore) -> None:
+        """Test write normalizes string trade_date to Date type."""
+        # Create DataFrame with string trade_date
+        df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000001],
+                "trade_date": ["2024-01-02", "2024-01-03"],
+                "adj_factor": [1.0, 0.95],
+            }
+        )
+
+        # Write should normalize string dates to Date type
+        _file_path, _checksum = store.write("adj_factor", df, 2024)
+
+        # Read back and verify dates are Date type
+        result = store.read("adj_factor")
+        assert result["trade_date"].dtype == pl.Date
+        assert len(result) == 2
+
+    def test_write_with_date_trade_date(self, store: AdjFactorStore) -> None:
+        """Test write preserves Date type trade_date."""
+        # Create DataFrame with Date trade_date
+        df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000001],
+                "trade_date": [date(2024, 1, 2), date(2024, 1, 3)],
+                "adj_factor": [1.0, 0.95],
+            }
+        )
+
+        # Write should preserve Date type
+        _file_path, _checksum = store.write("adj_factor", df, 2024)
+
+        # Read back and verify dates are Date type
+        result = store.read("adj_factor")
+        assert result["trade_date"].dtype == pl.Date
+        assert len(result) == 2
+
+    def test_write_with_invalid_date_format_raises_error(
+        self, store: AdjFactorStore
+    ) -> None:
+        """Test write raises error for invalid date format."""
+        # Create DataFrame with invalid date format
+        df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": ["not-a-date"],
+                "adj_factor": [1.0],
+            }
+        )
+
+        # Should raise InvalidOperationError for invalid date format
+        with pytest.raises(pl.InvalidOperationError):
+            store.write("adj_factor", df, 2024)

--- a/packages/datahub/tests/unit/meta/test_schema_validator.py
+++ b/packages/datahub/tests/unit/meta/test_schema_validator.py
@@ -1,0 +1,110 @@
+"""Tests for schema validation."""
+
+import polars as pl
+import pytest
+from ditto_datahub.meta.schema_validator import (
+    ValidationError,
+    validate_dataframe_schema,
+)
+
+
+class TestValidateDataFrameSchema:
+    """Tests for validate_dataframe_schema function."""
+
+    def test_validate_passes_for_valid_stock_daily_schema(self) -> None:
+        """Test validation passes for valid stock_daily DataFrame."""
+        df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": [pl.date(2024, 1, 1)],
+                "source": ["tushare"],
+                "src_code": ["000001.SZ"],
+                "open": [10.0],
+                "high": [11.0],
+                "low": [9.0],
+                "close": [10.5],
+                "pre_close": [10.0],
+                "volume": [1000.0],
+                "amount": [10000.0],
+                "pct_change": [5.0],
+                "turnover": [0.5],
+                "is_suspended": [False],
+                "is_limit_up": [False],
+                "is_limit_down": [False],
+                "is_st": [False],
+            }
+        )
+
+        # Should not raise
+        validate_dataframe_schema(df, "stock_daily")
+
+    def test_validate_passes_for_valid_adj_factor_schema(self) -> None:
+        """Test validation passes for valid adj_factor DataFrame."""
+        df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": [pl.date(2024, 1, 1)],
+                "source": ["tushare"],
+                "src_code": ["000001.SZ"],
+                "adj_factor": [1.0],
+            }
+        )
+
+        # Should not raise
+        validate_dataframe_schema(df, "adj_factor")
+
+    def test_validate_raises_on_missing_required_column(self) -> None:
+        """Test validation raises ValidationError for missing column."""
+        df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                # Missing "trade_date" column
+                "source": ["tushare"],
+                "src_code": ["000001.SZ"],
+            }
+        )
+
+        with pytest.raises(ValidationError, match="Missing required columns"):
+            validate_dataframe_schema(df, "stock_daily")
+
+    def test_validate_raises_on_wrong_column_type(self) -> None:
+        """Test validation raises ValidationError for wrong column type."""
+        df = pl.DataFrame(
+            {
+                "sid": ["not_an_int"],  # Should be Int64
+                "trade_date": [pl.date(2024, 1, 1)],
+                "source": ["tushare"],
+                "src_code": ["000001.SZ"],
+                "open": [10.0],
+                "high": [11.0],
+                "low": [9.0],
+                "close": [10.5],
+                "pre_close": [10.0],
+                "volume": [1000.0],
+                "amount": [10000.0],
+                "pct_change": [5.0],
+                "turnover": [0.5],
+                "is_suspended": [False],
+                "is_limit_up": [False],
+                "is_limit_down": [False],
+                "is_st": [False],
+            }
+        )
+
+        with pytest.raises(ValidationError, match="Column 'sid' has wrong type"):
+            validate_dataframe_schema(df, "stock_daily")
+
+    def test_validate_skips_unknown_dataset(self) -> None:
+        """Test validation skips validation for unknown dataset."""
+        df = pl.DataFrame({"any": ["column"]})
+
+        # Should not raise for unknown datasets
+        validate_dataframe_schema(df, "unknown_dataset")
+
+    def test_validate_handles_empty_dataframe(self) -> None:
+        """Test validation handles empty DataFrame gracefully."""
+        df = pl.DataFrame()
+
+        # Empty DataFrame should fail schema validation
+        with pytest.raises(ValidationError, match="Missing required columns"):
+            validate_dataframe_schema(df, "stock_daily")

--- a/packages/datahub/tests/unit/meta/test_schema_validator.py
+++ b/packages/datahub/tests/unit/meta/test_schema_validator.py
@@ -1,5 +1,7 @@
 """Tests for schema validation."""
 
+from datetime import date
+
 import polars as pl
 import pytest
 from ditto_datahub.meta.schema_validator import (
@@ -16,7 +18,7 @@ class TestValidateDataFrameSchema:
         df = pl.DataFrame(
             {
                 "sid": [100000001],
-                "trade_date": [pl.date(2024, 1, 1)],
+                "trade_date": [date(2024, 1, 1)],
                 "source": ["tushare"],
                 "src_code": ["000001.SZ"],
                 "open": [10.0],
@@ -43,7 +45,7 @@ class TestValidateDataFrameSchema:
         df = pl.DataFrame(
             {
                 "sid": [100000001],
-                "trade_date": [pl.date(2024, 1, 1)],
+                "trade_date": [date(2024, 1, 1)],
                 "source": ["tushare"],
                 "src_code": ["000001.SZ"],
                 "adj_factor": [1.0],
@@ -72,7 +74,7 @@ class TestValidateDataFrameSchema:
         df = pl.DataFrame(
             {
                 "sid": ["not_an_int"],  # Should be Int64
-                "trade_date": [pl.date(2024, 1, 1)],
+                "trade_date": [date(2024, 1, 1)],
                 "source": ["tushare"],
                 "src_code": ["000001.SZ"],
                 "open": [10.0],

--- a/packages/datahub/tests/unit/repositories/test_bars_repository.py
+++ b/packages/datahub/tests/unit/repositories/test_bars_repository.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 
 import polars as pl
 import pytest
-from ditto_datahub.repositories.bars import BarsRepository
+from ditto_datahub.repositories.bars import AdjType, BarsRepository
 from ditto_datahub.runtime.dq_checker import DQChecker
 from ditto_datahub.runtime.file_lock import FileLockManager
 from ditto_datahub.runtime.sqlite_pool import SQLitePool
@@ -125,6 +125,134 @@ class TestBarsRepository:
         # Assert
         assert "symbol" in result.columns
         assert result["symbol"][0] == "600000"
+
+
+class TestQFQAdjustment:
+    """Tests for QFQ (前复权) adjustment."""
+
+    def setup_method(self) -> None:
+        """Set up test environment."""
+        self.temp_dir = TemporaryDirectory()
+        data_root = Path(self.temp_dir.name)
+
+        self.pool = SQLitePool(":memory:")
+        self.pool.init_schema()
+        self.client = SQLiteClient(self.pool)
+
+        self.bars_store = BarsStore(data_root)
+        self.adj_factor_store = AdjFactorStore(data_root)
+        self.security_store = SecurityStore(self.client)
+        self.dq_checker = DQChecker()
+        self.file_lock_manager = FileLockManager(data_root / "locks")
+
+        self.repo = BarsRepository(
+            self.bars_store,
+            self.adj_factor_store,
+            self.security_store,
+            self.dq_checker,
+            self.file_lock_manager,
+        )
+
+        # Insert test security
+        self.client.execute("""
+            INSERT INTO security
+            (sid, symbol, name, exchange, asset_class, list_date)
+            VALUES (100000001, '600000', 'Test Stock', 'SSE', 'stock', '2000-01-01')
+        """)
+        self.client.commit()
+
+    def teardown_method(self) -> None:
+        """Clean up test environment."""
+        self.temp_dir.cleanup()
+
+    def test_qfq_uses_latest_adj_factor(self) -> None:
+        """Test that QFQ adjustment uses the latest adj_factor correctly."""
+        # Arrange: Write bars data with consistent prices
+        bars_df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000001, 100000001],
+                "trade_date": [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)],
+                "open": [10.0, 10.0, 10.0],
+                "high": [12.0, 12.0, 12.0],
+                "low": [9.0, 9.0, 9.0],
+                "close": [11.0, 11.0, 11.0],
+                "volume": [1000, 2000, 3000],
+            }
+        )
+        self.bars_store.write("stock_daily", bars_df, 2024)
+
+        # Write adj_factor data: 0.95 on 2024-01-03 and later
+        adj_df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000001, 100000001],
+                "trade_date": [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)],
+                "adj_factor": [1.0, 0.95, 0.95],
+            }
+        )
+        self.adj_factor_store.write("adj_factor", adj_df, 2024)
+
+        # Act: Get QFQ adjusted data
+        result = self.repo.get(
+            sids=[100000001],
+            start="2024-01-02",
+            end="2024-01-04",
+            adj=AdjType.QFQ,
+        )
+
+        # Assert: QFQ should adjust all prices using the latest factor (0.95)
+        # Formula: adjusted_price = original_price * latest_factor / adj_factor
+        # 2024-01-02: 11.0 * 0.95 / 1.0 = 10.45
+        # 2024-01-03: 11.0 * 0.95 / 0.95 = 11.0
+        # 2024-01-04: 11.0 * 0.95 / 0.95 = 11.0
+        result_sorted = result.sort("trade_date")
+        assert len(result_sorted) == 3
+        assert abs(result_sorted["close"][0] - 10.45) < 0.01  # 2024-01-02
+        assert abs(result_sorted["close"][1] - 11.00) < 0.01  # 2024-01-03
+        assert abs(result_sorted["close"][2] - 11.00) < 0.01  # 2024-01-04
+
+
+class TestBarsRepositorySingle:
+    """Tests for get_single method."""
+
+    def setup_method(self) -> None:
+        """Set up test environment."""
+        self.temp_dir = TemporaryDirectory()
+        data_root = Path(self.temp_dir.name)
+
+        self.pool = SQLitePool(":memory:")
+        self.pool.init_schema()
+        self.client = SQLiteClient(self.pool)
+
+        self.bars_store = BarsStore(data_root)
+        self.adj_factor_store = AdjFactorStore(data_root)
+        self.security_store = SecurityStore(self.client)
+        self.dq_checker = DQChecker()
+        self.file_lock_manager = FileLockManager(data_root / "locks")
+
+        self.repo = BarsRepository(
+            self.bars_store,
+            self.adj_factor_store,
+            self.security_store,
+            self.dq_checker,
+            self.file_lock_manager,
+        )
+
+        # Insert test security
+        self.client.execute("""
+            INSERT INTO security
+            (sid, symbol, name, exchange, asset_class, list_date)
+            VALUES (100000001, '600000', 'Test', 'SSE', 'stock', '2000-01-01')
+        """)
+        self.client.execute("""
+            INSERT INTO security_mapping
+            (sid, source, src_code, effective_from)
+            VALUES (100000001, 'tushare', '600000.SH', '2000-01-01')
+        """)
+        self.client.commit()
+
+    def teardown_method(self) -> None:
+        """Clean up test environment."""
+        self.temp_dir.cleanup()
 
     def test_get_single_by_src_code(self) -> None:
         """Test get_single resolves src_code."""

--- a/packages/datahub/tests/unit/repositories/test_bars_repository.py
+++ b/packages/datahub/tests/unit/repositories/test_bars_repository.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import polars as pl
+import pytest
 from ditto_datahub.repositories.bars import BarsRepository
 from ditto_datahub.runtime.dq_checker import DQChecker
 from ditto_datahub.runtime.file_lock import FileLockManager
@@ -208,3 +209,79 @@ class TestBarsRepository:
         assert result.rows_written == 1
         assert result.file_path is not None
         assert result.checksum is not None
+
+
+class TestMixedAssetClass:
+    """Tests for mixed asset class handling."""
+
+    def setup_method(self) -> None:
+        """Set up test environment."""
+        self.temp_dir = TemporaryDirectory()
+        data_root = Path(self.temp_dir.name)
+
+        self.pool = SQLitePool(":memory:")
+        self.pool.init_schema()
+        self.client = SQLiteClient(self.pool)
+
+        self.bars_store = BarsStore(data_root)
+        self.adj_factor_store = AdjFactorStore(data_root)
+        self.security_store = SecurityStore(self.client)
+        self.dq_checker = DQChecker()
+        self.file_lock_manager = FileLockManager(data_root / "locks")
+
+        self.repo = BarsRepository(
+            self.bars_store,
+            self.adj_factor_store,
+            self.security_store,
+            self.dq_checker,
+            self.file_lock_manager,
+        )
+
+        # Insert stock security (SID: 100,000,000 - 199,999,999)
+        self.client.execute("""
+            INSERT INTO security
+            (sid, symbol, name, exchange, asset_class, list_date)
+            VALUES (100000001, '600000', 'Test Stock', 'SSE', 'stock', '2000-01-01')
+        """)
+
+        # Insert ETF security (SID: 200,000,000 - 299,999,999)
+        self.client.execute("""
+            INSERT INTO security
+            (sid, symbol, name, exchange, asset_class, list_date)
+            VALUES (200000001, '510300', 'Test ETF', 'SSE', 'etf', '2000-01-01')
+        """)
+        self.client.commit()
+
+    def teardown_method(self) -> None:
+        """Clean up test environment."""
+        self.temp_dir.cleanup()
+
+    def test_get_with_mixed_sids_raises_error(self) -> None:
+        """Test that mixed stock/ETF SIDs raise ValueError."""
+        # Act & Assert
+        with pytest.raises(ValueError, match="Mixed asset class query"):
+            self.repo.get(
+                sids=[100000001, 200000001],  # stock + ETF
+                start="2024-01-01",
+                end="2024-01-31",
+            )
+
+    def test_get_with_all_stock_sids_succeeds(self) -> None:
+        """Test that all stock SIDs succeed."""
+        # Should not raise
+        result = self.repo.get(
+            sids=[100000001, 100000002],  # both stocks
+            start="2024-01-01",
+            end="2024-01-31",
+        )
+        assert isinstance(result, pl.DataFrame)
+
+    def test_get_with_all_etf_sids_succeeds(self) -> None:
+        """Test that all ETF SIDs succeed."""
+        # Should not raise
+        result = self.repo.get(
+            sids=[200000001, 200000002],  # both ETFs
+            start="2024-01-01",
+            end="2024-01-31",
+        )
+        assert isinstance(result, pl.DataFrame)

--- a/packages/datahub/tests/unit/repositories/test_bars_repository.py
+++ b/packages/datahub/tests/unit/repositories/test_bars_repository.py
@@ -3,6 +3,7 @@
 from datetime import date
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 import polars as pl
 import pytest
@@ -424,6 +425,62 @@ class TestBarsRepositorySingle:
 
         # Assert
         assert len(result) == 1
+
+    def test_get_single_warns_on_multiple_symbol_matches(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test get_single warns when symbol maps to multiple SIDs."""
+        # Arrange: Insert multiple securities with same symbol (unlikely but possible)
+        self.client.execute("""
+            INSERT INTO security
+            (sid, symbol, name, exchange, asset_class, list_date)
+            VALUES (100000002, '600000', 'Another Stock', 'SZSE', 'stock', '2000-01-01')
+        """)
+        self.client.execute("""
+            INSERT INTO security_mapping
+            (sid, source, src_code, effective_from)
+            VALUES (100000002, 'tushare', '600000.SZ', '2000-01-01')
+        """)
+        self.client.commit()
+
+        # Arrange: Write test data
+        test_df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": [date(2024, 1, 2)],
+                "open": [10.0],
+                "high": [12.0],
+                "low": [9.0],
+                "close": [11.0],
+                "volume": [1000],
+            }
+        )
+        self.bars_store.write("stock_daily", test_df, 2024)
+
+        # Act: Mock logger and call get_single
+        with patch("ditto_datahub.repositories.bars.logger") as mock_logger:
+            result = self.repo.get_single(
+                identifier="600000",
+                start="2024-01-01",
+                end="2024-01-31",
+                source="tushare",
+            )
+
+        # Assert: Should return first SID's data
+        assert len(result) == 1
+        assert result["sid"][0] == 100000001
+
+        # Assert: logger.warning should have been called with correct arguments
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert call_args is not None
+        # Extract the positional and keyword arguments
+        # logger.warning(message, event=..., symbol=..., etc.)
+        args, kwargs = call_args
+        assert "Multiple SIDs found for symbol" in args[0]
+        assert kwargs["event"] == "symbol_multiple_matches"
+        assert kwargs["symbol"] == "600000"
+        assert kwargs["match_count"] == 2
 
     def test_write_returns_write_result(self) -> None:
         """Test write returns WriteResult."""

--- a/packages/datahub/tests/unit/repositories/test_bars_repository.py
+++ b/packages/datahub/tests/unit/repositories/test_bars_repository.py
@@ -210,6 +210,122 @@ class TestQFQAdjustment:
         assert abs(result_sorted["close"][1] - 11.00) < 0.01  # 2024-01-03
         assert abs(result_sorted["close"][2] - 11.00) < 0.01  # 2024-01-04
 
+    def test_qfq_with_missing_adj_factor_uses_original_price(self) -> None:
+        """Test QFQ adjustment handles missing adj_factor gracefully."""
+        # Arrange: Write bars data
+        bars_df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000001],
+                "trade_date": [date(2024, 1, 2), date(2024, 1, 3)],
+                "open": [10.0, 11.0],
+                "high": [12.0, 13.0],
+                "low": [9.0, 10.0],
+                "close": [11.0, 12.0],
+                "volume": [1000, 2000],
+            }
+        )
+        self.bars_store.write("stock_daily", bars_df, 2024)
+
+        # Write adj_factor data only for 2024-01-03 (missing for 2024-01-02)
+        adj_df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": [date(2024, 1, 3)],
+                "adj_factor": [0.95],
+            }
+        )
+        self.adj_factor_store.write("adj_factor", adj_df, 2024)
+
+        # Act: Get QFQ adjusted data
+        result = self.repo.get(
+            sids=[100000001],
+            start="2024-01-02",
+            end="2024-01-03",
+            adj=AdjType.QFQ,
+        )
+
+        # Assert: QFQ uses latest_factor (0.95) for all dates
+        # 2024-01-02: 11.0 * 0.95 / 1.0 (coalesced null adj_factor) = 10.45
+        # 2024-01-03: 12.0 * 0.95 / 0.95 = 12.0
+        result_sorted = result.sort("trade_date")
+        assert len(result_sorted) == 2
+        assert abs(result_sorted["close"][0] - 10.45) < 0.01  # 2024-01-02
+        assert abs(result_sorted["close"][1] - 12.00) < 0.01  # 2024-01-03
+
+    def test_qfq_with_no_adj_factor_returns_original_price(self) -> None:
+        """Test QFQ with no adj_factor data returns original prices."""
+        # Arrange: Write bars data without adj_factor
+        bars_df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000001],
+                "trade_date": [date(2024, 1, 2), date(2024, 1, 3)],
+                "open": [10.0, 11.0],
+                "high": [12.0, 13.0],
+                "low": [9.0, 10.0],
+                "close": [11.0, 12.0],
+                "volume": [1000, 2000],
+            }
+        )
+        self.bars_store.write("stock_daily", bars_df, 2024)
+
+        # Act: Get QFQ adjusted data (no adj_factor available)
+        result = self.repo.get(
+            sids=[100000001],
+            start="2024-01-02",
+            end="2024-01-03",
+            adj=AdjType.QFQ,
+        )
+
+        # Assert: Should return original prices when no adj_factor data
+        result_sorted = result.sort("trade_date")
+        assert len(result_sorted) == 2
+        assert abs(result_sorted["close"][0] - 11.0) < 0.01  # 2024-01-02
+        assert abs(result_sorted["close"][1] - 12.0) < 0.01  # 2024-01-03
+
+    def test_hfq_with_missing_adj_factor_uses_original_price(self) -> None:
+        """Test HFQ adjustment falls back to original price when adj_factor missing."""
+        # Arrange: Write bars data
+        bars_df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000001],
+                "trade_date": [date(2024, 1, 2), date(2024, 1, 3)],
+                "open": [10.0, 11.0],
+                "high": [12.0, 13.0],
+                "low": [9.0, 10.0],
+                "close": [11.0, 12.0],
+                "volume": [1000, 2000],
+            }
+        )
+        self.bars_store.write("stock_daily", bars_df, 2024)
+
+        # Write adj_factor data only for 2024-01-02 (missing for 2024-01-03)
+        adj_df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": [date(2024, 1, 2)],
+                "adj_factor": [0.95],
+            }
+        )
+        self.adj_factor_store.write("adj_factor", adj_df, 2024)
+
+        # Act: Get HFQ adjusted data
+        result = self.repo.get(
+            sids=[100000001],
+            start="2024-01-02",
+            end="2024-01-03",
+            adj=AdjType.HFQ,
+        )
+
+        # Assert: Missing adj_factor should use original price
+        # 2024-01-02: 11.0 * 0.95 = 10.45
+        # 2024-01-03: 12.0 * 1.0 = 12.0 (no adj_factor, uses original)
+        result_sorted = result.sort("trade_date")
+        assert len(result_sorted) == 2
+        assert abs(result_sorted["close"][0] - 10.45) < 0.01  # 2024-01-02
+        assert (
+            abs(result_sorted["close"][1] - 12.00) < 0.01
+        )  # 2024-01-03 (no adj factor)
+
 
 class TestBarsRepositorySingle:
     """Tests for get_single method."""

--- a/packages/datahub/tests/unit/runtime/test_sqlite_pool.py
+++ b/packages/datahub/tests/unit/runtime/test_sqlite_pool.py
@@ -1,8 +1,10 @@
 """Tests for SQLite Pool."""
 
+import sqlite3
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import pytest
 from ditto_datahub.runtime.sqlite_pool import SQLitePool
 
 
@@ -170,3 +172,55 @@ class TestSQLitePool:
         # but we can verify the pool is still functional with a new connection
         new_conn = self.pool.get_connection()
         assert new_conn is not None
+
+    def test_foreign_key_constraint_enforced(self) -> None:
+        """Test that foreign key constraints are enforced."""
+        self.pool = SQLitePool(str(self.db_path))
+        self.pool.init_schema()
+
+        # Insert a valid security first
+        self.pool.execute(
+            "INSERT INTO security "
+            "(sid, symbol, name, exchange, asset_class, list_date) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [100000001, "600000", "Test", "SSE", "stock", "2000-01-01"],
+        )
+        self.pool.commit()
+
+        # Try to insert a mapping with invalid SID (should fail)
+        with pytest.raises(sqlite3.IntegrityError):
+            self.pool.execute(
+                "INSERT INTO security_mapping (sid, source, src_code, effective_from) "
+                "VALUES (?, ?, ?, ?)",
+                [999999, "tushare", "INVALID", "2000-01-01"],
+            )
+
+    def test_foreign_key_constraint_allows_valid_mapping(self) -> None:
+        """Test that foreign key constraints allow valid mappings."""
+        self.pool = SQLitePool(str(self.db_path))
+        self.pool.init_schema()
+
+        # Insert a valid security
+        self.pool.execute(
+            "INSERT INTO security "
+            "(sid, symbol, name, exchange, asset_class, list_date) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [100000001, "600000", "Test", "SSE", "stock", "2000-01-01"],
+        )
+        self.pool.commit()
+
+        # Should allow valid mapping
+        self.pool.execute(
+            "INSERT INTO security_mapping (sid, source, src_code, effective_from) "
+            "VALUES (?, ?, ?, ?)",
+            [100000001, "tushare", "600000.SH", "2000-01-01"],
+        )
+        self.pool.commit()
+
+        # Verify it was inserted
+        rows = self.pool.execute(
+            "SELECT COUNT(*) as count FROM security_mapping WHERE sid = ?",
+            [100000001],
+        ).fetchall()
+        count = rows[0]["count"]
+        assert count == 1

--- a/packages/datahub/tests/unit/runtime/test_sqlite_pool.py
+++ b/packages/datahub/tests/unit/runtime/test_sqlite_pool.py
@@ -33,6 +33,15 @@ class TestSQLitePool:
         assert conn is not None
         assert hasattr(conn, "execute")
 
+    def test_get_connection_returns_correct_type(self) -> None:
+        """Test get_connection returns sqlite3.Connection without runtime cast."""
+        self.pool = SQLitePool(str(self.db_path))
+        conn = self.pool.get_connection()
+
+        # Verify the returned type is sqlite3.Connection
+        # Type should be inferred correctly by mypy without runtime cast
+        assert isinstance(conn, sqlite3.Connection)
+
     def test_get_connection_is_thread_local(self) -> None:
         """Test get_connection returns thread-local connection."""
         self.pool = SQLitePool(str(self.db_path))

--- a/packages/datahub/tests/unit/stores/test_bars_store.py
+++ b/packages/datahub/tests/unit/stores/test_bars_store.py
@@ -193,3 +193,140 @@ class TestBarsStore:
         # Try to delete non-existent partition
         result = self.store.delete("market_daily", 2024)
         assert result is False
+
+
+class TestBarsStoreRefactoredHelpers:
+    """Tests for refactored helper methods in BarsStore."""
+
+    def setup_method(self) -> None:
+        """Set up test environment."""
+        self.temp_dir = TemporaryDirectory()
+        self.store = BarsStore(Path(self.temp_dir.name))
+
+    def teardown_method(self) -> None:
+        """Clean up test environment."""
+        self.temp_dir.cleanup()
+
+    def test_ensure_dataset_dir_creates_directory(self) -> None:
+        """Test _ensure_dataset_dir creates dataset directory."""
+        dataset = "test_dataset"
+        result_path = self.store._ensure_dataset_dir(dataset)
+
+        assert result_path == Path(self.temp_dir.name) / dataset
+        assert result_path.exists()
+        assert result_path.is_dir()
+
+    def test_ensure_dataset_dir_is_idempotent(self) -> None:
+        """Test _ensure_dataset_dir can be called multiple times safely."""
+        dataset = "test_dataset"
+        path1 = self.store._ensure_dataset_dir(dataset)
+        path2 = self.store._ensure_dataset_dir(dataset)
+
+        assert path1 == path2
+        assert path1.exists()
+
+    def test_merge_with_existing_returns_new_data_when_no_file(self) -> None:
+        """Test _merge_with_existing returns new data when file doesn't exist."""
+        new_df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": [date(2024, 1, 1)],
+                "open": [10.0],
+                "high": [12.0],
+                "low": [9.0],
+                "close": [11.0],
+                "volume": [1000],
+            }
+        )
+        non_existent_path = Path(self.temp_dir.name) / "nonexistent.parquet"
+
+        result = self.store._merge_with_existing(new_df, non_existent_path)
+
+        # Should return new data as-is
+        assert len(result) == 1
+        assert result["sid"][0] == 100000001
+
+    def test_merge_with_existing_merges_when_file_exists(self) -> None:
+        """Test _merge_with_existing merges data when file exists."""
+        # First write initial data
+        initial_df = pl.DataFrame(
+            {
+                "sid": [100000001],
+                "trade_date": [date(2024, 1, 1)],
+                "open": [10.0],
+                "high": [12.0],
+                "low": [9.0],
+                "close": [11.0],
+                "volume": [1000],
+            }
+        )
+        self.store.write("market_daily", initial_df, 2024)
+
+        # Create new data with overlap
+        new_df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000002],
+                "trade_date": [date(2024, 1, 1), date(2024, 1, 2)],
+                "open": [10.5, 11.0],
+                "high": [12.5, 13.0],
+                "low": [9.5, 10.0],
+                "close": [11.5, 12.0],
+                "volume": [1500, 2000],
+            }
+        )
+
+        file_path = self.store._get_path("market_daily", 2024)
+        result = self.store._merge_with_existing(new_df, file_path)
+
+        # Should have 2 unique records
+        assert len(result) == 2
+        # The overlapped record should be updated
+        record = result.filter(pl.col("sid") == 100000001)
+        assert record["close"][0] == 11.5
+
+    def test_prepare_for_write_normalizes_dates(self) -> None:
+        """Test _prepare_for_write normalizes date types."""
+        # Create DataFrame with string dates
+        df = pl.DataFrame(
+            {
+                "sid": [100000001, 100000002],
+                "trade_date": ["2024-01-01", "2024-01-02"],
+                "open": [10.0, 11.0],
+                "high": [12.0, 13.0],
+                "low": [9.0, 10.0],
+                "close": [11.0, 12.0],
+                "volume": [1000, 2000],
+            }
+        )
+
+        result = self.store._prepare_for_write(df)
+
+        # Dates should be Date type
+        assert result["trade_date"].dtype == pl.Date
+        # Data should be sorted by trade_date, sid
+        assert result[0]["trade_date"] == date(2024, 1, 1)
+
+    def test_prepare_for_write_sorts_data(self) -> None:
+        """Test _prepare_for_write sorts data correctly."""
+        # Create intentionally unsorted data
+        df = pl.DataFrame(
+            {
+                "sid": [100000002, 100000001, 100000002],
+                "trade_date": [date(2024, 1, 2), date(2024, 1, 1), date(2024, 1, 1)],
+                "open": [11.0, 10.0, 11.0],
+                "high": [13.0, 12.0, 13.0],
+                "low": [10.0, 9.0, 10.0],
+                "close": [12.0, 11.0, 12.0],
+                "volume": [2000, 1000, 2000],
+            }
+        )
+
+        result = self.store._prepare_for_write(df)
+
+        # Should be sorted by trade_date, then sid
+        # First row should be 2024-01-01, sid=100000001
+        assert result[0]["trade_date"] == date(2024, 1, 1)
+        assert result[0]["sid"] == 100000001
+        # Last row should be 2024-01-02, sid=100000002
+        assert result[2]["trade_date"] == date(2024, 1, 2)
+        assert result[2]["sid"] == 100000002

--- a/packages/datahub/tests/unit/stores/test_bars_store.py
+++ b/packages/datahub/tests/unit/stores/test_bars_store.py
@@ -304,7 +304,9 @@ class TestBarsStoreRefactoredHelpers:
         # Dates should be Date type
         assert result["trade_date"].dtype == pl.Date
         # Data should be sorted by trade_date, sid
-        assert result[0]["trade_date"] == date(2024, 1, 1)
+        # Use row() or proper indexing for single row access
+        first_row = result.row(0)
+        assert first_row[1] == date(2024, 1, 1)
 
     def test_prepare_for_write_sorts_data(self) -> None:
         """Test _prepare_for_write sorts data correctly."""
@@ -325,8 +327,10 @@ class TestBarsStoreRefactoredHelpers:
 
         # Should be sorted by trade_date, then sid
         # First row should be 2024-01-01, sid=100000001
-        assert result[0]["trade_date"] == date(2024, 1, 1)
-        assert result[0]["sid"] == 100000001
+        first_row = result.row(0)
+        assert first_row[1] == date(2024, 1, 1)
+        assert first_row[0] == 100000001
         # Last row should be 2024-01-02, sid=100000002
-        assert result[2]["trade_date"] == date(2024, 1, 2)
-        assert result[2]["sid"] == 100000002
+        last_row = result.row(2)
+        assert last_row[1] == date(2024, 1, 2)
+        assert last_row[0] == 100000002

--- a/packages/datahub/tests/unit/stores/test_security_store.py
+++ b/packages/datahub/tests/unit/stores/test_security_store.py
@@ -288,3 +288,92 @@ class TestSecurityStore:
         """Clean up after test."""
         # No cleanup needed for in-memory database
         pass
+
+
+class TestSqlInjectionProtection:
+    """Tests for SQL injection protection in IN clause construction."""
+
+    def setup_method(self) -> None:
+        """Set up test database."""
+        self.pool = SQLitePool(":memory:")
+        self.pool.init_schema()
+        self.client = SQLiteClient(self.pool)
+        self.store = SecurityStore(self.client)
+
+    def test_in_clause_with_many_sids(self) -> None:
+        """Test IN clause handles large list of SIDs safely."""
+        # Insert test data for 100 securities
+        for i in range(100):
+            sid = 100000001 + i
+            self.client.execute(
+                """INSERT INTO security
+                (sid, symbol, name, exchange, asset_class, list_date, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, TRUE)""",
+                [sid, f"60{i:04d}", f"Stock{i}", "SSE", "stock", "2000-01-01"],
+            )
+        self.client.commit()
+
+        # Query with 100 SIDs
+        sids = list(range(100000001, 100000101))
+        result = self.store.find_securities(sids=sids)
+
+        # Should return all 100 securities
+        assert len(result) == 100
+
+    def test_in_clause_with_single_sid(self) -> None:
+        """Test IN clause works with single SID."""
+        self.client.execute(
+            """INSERT INTO security
+            (sid, symbol, name, exchange, asset_class, list_date, is_active)
+            VALUES (100000001, '600000', 'Test', 'SSE', 'stock', '2000-01-01', TRUE)"""
+        )
+        self.client.commit()
+
+        result = self.store.find_securities(sids=[100000001])
+        assert len(result) == 1
+        assert result["sid"][0] == 100000001
+
+    def test_get_sid_symbol_map_with_many_sids(self) -> None:
+        """Test get_sid_symbol_map with large list."""
+        # Insert test data for 50 securities
+        for i in range(50):
+            sid = 100000001 + i
+            self.client.execute(
+                """INSERT INTO security
+                (sid, symbol, name, exchange, asset_class, list_date, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, TRUE)""",
+                [sid, f"60{i:04d}", f"Stock{i}", "SSE", "stock", "2000-01-01"],
+            )
+        self.client.commit()
+
+        # Query with 50 SIDs
+        sids = list(range(100000001, 100000051))
+        mapping = self.store.get_sid_symbol_map(sids)
+
+        # Should return all 50 mappings
+        assert len(mapping) == 50
+        assert mapping[100000001] == "600000"
+        assert mapping[100000050] == "600049"  # i=49 produces "600049"
+
+    def test_special_characters_in_src_code(self) -> None:
+        """Test special characters in src_code are handled safely."""
+        self.client.execute(
+            """INSERT INTO security
+            (sid, symbol, name, exchange, asset_class, list_date)
+            VALUES (100000001, 'TEST', 'Test', 'SSE', 'stock', '2000-01-01')"""
+        )
+        # Use src_code with special characters that could be SQL injection attempts
+        self.client.execute(
+            """INSERT INTO security_mapping
+            (sid, source, src_code, effective_from)
+            VALUES (100000001, 'tushare', 'test;DROP TABLE security--', '2000-01-01')"""
+        )
+        self.client.commit()
+
+        # Should safely query without executing the injection
+        sid = self.store.resolve_sid("test;DROP TABLE security--", "tushare", asof=None)
+        assert sid == 100000001
+
+        # Verify the security table still exists
+        result = self.client.fetchall("SELECT COUNT(*) as count FROM security")
+        assert result[0]["count"] >= 1

--- a/packages/datahub/tests/unit/test_errors.py
+++ b/packages/datahub/tests/unit/test_errors.py
@@ -1,0 +1,59 @@
+"""Tests for DataHub error types."""
+
+from ditto_datahub.errors import (
+    DataHubError,
+    DatasetNotFoundError,
+    PartitionNotFoundError,
+    ValidationError,
+)
+
+
+class TestValidationError:
+    """Tests for ValidationError."""
+
+    def test_validation_error_is_datahub_error(self) -> None:
+        """Test ValidationError inherits from DataHubError."""
+        error = ValidationError("Test error")
+        assert isinstance(error, DataHubError)
+        assert str(error) == "Test error"
+
+    def test_validation_error_with_details(self) -> None:
+        """Test ValidationError can store details."""
+        error = ValidationError(
+            "Schema validation failed",
+            details={"column": "sid", "expected": "Int64"},
+        )
+        assert error.details == {"column": "sid", "expected": "Int64"}
+
+
+class TestDatasetNotFoundError:
+    """Tests for DatasetNotFoundError."""
+
+    def test_dataset_not_found_error_is_datahub_error(self) -> None:
+        """Test DatasetNotFoundError inherits from DataHubError."""
+        error = DatasetNotFoundError("Dataset not found")
+        assert isinstance(error, DataHubError)
+
+    def test_dataset_not_found_error_with_dataset(self) -> None:
+        """Test DatasetNotFoundError stores dataset name."""
+        error = DatasetNotFoundError(dataset="stock_daily")
+        assert error.details == {"dataset": "stock_daily"}
+
+
+class TestPartitionNotFoundError:
+    """Tests for PartitionNotFoundError."""
+
+    def test_partition_not_found_error_is_datahub_error(self) -> None:
+        """Test PartitionNotFoundError inherits from DataHubError."""
+        error = PartitionNotFoundError("Partition not found")
+        assert isinstance(error, DataHubError)
+
+    def test_partition_not_found_error_with_details(self) -> None:
+        """Test PartitionNotFoundError stores details."""
+        error = PartitionNotFoundError(dataset="stock_daily", year=2024)
+        assert error.details == {"dataset": "stock_daily", "year": 2024}
+
+    def test_partition_not_found_error_partial_details(self) -> None:
+        """Test PartitionNotFoundError with partial details."""
+        error = PartitionNotFoundError(dataset="stock_daily")
+        assert error.details == {"dataset": "stock_daily"}

--- a/packages/datahub/tests/unit/utils/test_date_utils.py
+++ b/packages/datahub/tests/unit/utils/test_date_utils.py
@@ -1,0 +1,59 @@
+"""Tests for date normalization utilities."""
+
+from datetime import date, datetime
+from typing import get_args
+
+import pytest
+from ditto_datahub.utils.dates import DateInput, normalize_date
+
+
+class TestNormalizeDate:
+    """Tests for normalize_date function."""
+
+    def test_normalize_string_date(self) -> None:
+        """Test normalize_date handles string dates."""
+        result = normalize_date("2024-01-15")
+        assert result == "2024-01-15"
+
+    def test_normalize_date_object(self) -> None:
+        """Test normalize_date handles date objects."""
+        input_date = date(2024, 1, 15)
+        result = normalize_date(input_date)
+        assert result == "2024-01-15"
+
+    def test_normalize_datetime_object(self) -> None:
+        """Test normalize_date handles datetime objects."""
+        input_dt = datetime(2024, 1, 15, 10, 30, 45)
+        result = normalize_date(input_dt)
+        assert result == "2024-01-15"  # Time component discarded
+
+    def test_normalize_none(self) -> None:
+        """Test normalize_date handles None."""
+        result = normalize_date(None)
+        assert result is None
+
+    def test_normalize_invalid_string_raises(self) -> None:
+        """Test normalize_date raises ValueError for invalid string."""
+        with pytest.raises(ValueError, match="Invalid date format"):
+            normalize_date("not-a-date")
+
+    def test_normalize_malformed_string_raises(self) -> None:
+        """Test normalize_date raises ValueError for malformed date."""
+        with pytest.raises(ValueError, match="Invalid date format"):
+            normalize_date("2024/01/15")  # Wrong separator
+
+    def test_date_input_type_exists(self) -> None:
+        """Test DateInput type alias is defined."""
+        # DateInput should be str | date | datetime | None
+        args = get_args(DateInput)
+        assert (
+            str in args
+            or args == (str, date, datetime, type(None))
+            or args
+            == (
+                str,
+                date,
+                datetime,
+                None,
+            )
+        )

--- a/packages/foundation/src/ditto_foundation/README.md
+++ b/packages/foundation/src/ditto_foundation/README.md
@@ -31,21 +31,16 @@ src/ditto_foundation/
 ├── config/                 # 配置管理
 │   ├── __init__.py
 │   └── settings.py         # Pydantic Settings (主配置)
-├── contracts/              # 数据契约
-│   ├── __init__.py
-│   ├── etf.py              # ETF Pydantic 模型
-│   └── market_data.py      # Market Data Pandera Schema
-├── observability/          # 可观测性模块 (NEW)
+├── observability/          # 可观测性模块
 │   ├── __init__.py         # 主入口: init(), shutdown()
 │   ├── config.py           # Mode, ObservabilityConfig
 │   ├── logging.py          # Loguru 日志配置
 │   ├── tracing.py          # OTel 追踪: span(), @traced, get_trace_id()
 │   ├── metrics.py          # M 类 (预定义指标)
 │   └── testing.py          # 测试辅助: reset_for_testing()
-├── types/                  # 共享类型
-│   └── __init__.py
 └── util/                   # 工具函数
-    ├── io.py               # IO 工具
+    ├── io.py               # IO 工具 (atomic_write, file_md5)
+    ├── dates.py            # 日期规范化 (normalize_date)
     └── __init__.py
 ```
 
@@ -158,17 +153,15 @@ M.data_update_duration.record(1.5, {"source": "tushare"})
   - `DatabaseSettings`: DuckDB/SQLite 配置
   - `ObservabilitySettings`: 可观测性配置
   - `DataSourceSettings`: Tushare/AkShare 配置
-  - `TradingSettings`: 交易执行配置
-  - `RiskSettings`: 风险管理配置 (Kill Switch)
+  - `APISettings`: FastAPI 服务配置
+  - `SystemSettings`: 系统基础配置
+  - `FileStorageSettings`: 文件存储配置
 - `get_settings()`: 全局配置单例
-
-### contracts/ - 数据契约
-- `ETFInfoModel`: ETF 信息 Pydantic 模型
-- `DailyPriceSchema`: 日线数据 Pandera Schema
 
 ### util/ - 工具函数
 - `atomic_write()`: 原子写入 Parquet
 - `file_md5()`: 文件 MD5 校验
+- `normalize_date()`: 日期格式规范化
 
 ### app_initializer - 应用初始化
 - `AppInitializer`: 应用初始化类

--- a/packages/foundation/src/ditto_foundation/config/README.md
+++ b/packages/foundation/src/ditto_foundation/config/README.md
@@ -18,11 +18,9 @@
 | `DatabaseSettings` | settings.py | 数据库配置（DuckDB + SQLite）|
 | `DataSourceSettings` | settings.py | 数据源配置（Tushare + AkShare）|
 | `APISettings` | settings.py | FastAPI 服务配置 |
-| `TradingSettings` | settings.py | 交易执行配置（Phase 2+）|
-| `RiskSettings` | settings.py | 风险管理配置 |
-| `NotificationSettings` | settings.py | 通知服务配置 |
 | `SystemSettings` | settings.py | 系统基础配置 |
 | `FileStorageSettings` | settings.py | 文件存储配置 |
+| `ObservabilitySettings` | settings.py | 可观测性配置 |
 
 ## 二、架构定位
 

--- a/packages/foundation/src/ditto_foundation/util/README.md
+++ b/packages/foundation/src/ditto_foundation/util/README.md
@@ -10,6 +10,7 @@
 |------|------|------|
 | `atomic_write()` | 原子写入 Parquet 文件 | 确保数据写入完整性 |
 | `file_md5()` | 计算文件 MD5 哈希 | 数据完整性校验、变更检测 |
+| `normalize_date()` | 规范化日期格式 | 统一日期输入处理 |
 
 ## 二、架构定位
 
@@ -32,8 +33,9 @@
 
 ```
 util/
-├── __init__.py    # 导出 atomic_write, file_md5
-└── io.py          # IO 相关工具函数
+├── __init__.py    # 导出 atomic_write, file_md5, normalize_date
+├── io.py          # IO 相关工具函数
+└── dates.py       # 日期规范化工具函数
 ```
 
 ## 四、关键模块说明
@@ -86,6 +88,37 @@ print(checksum)  # 输出: "3a7bd3e2360a..."
 - 数据完整性校验
 - 文件变更检测
 - 缓存失效判断
+
+### 4.3 normalize_date()
+
+**功能**：将各种日期类型规范化为 YYYY-MM-DD 格式
+
+**支持的输入类型**：
+- `str`：YYYY-MM-DD 格式字符串
+- `datetime`：datetime 对象
+- `date`：date 对象
+- `None`：返回 None
+
+**特点**：
+- 使用 `DateInput` 类型别名统一输入类型
+- 完整的类型注解
+- 自动验证字符串格式
+
+```python
+from ditto_foundation.util import normalize_date, DateInput
+from datetime import date, datetime
+
+# 支持多种输入
+result1 = normalize_date("2024-01-02")      # "2024-01-02"
+result2 = normalize_date(date(2024, 1, 2))  # "2024-01-02"
+result3 = normalize_date(datetime(2024, 1, 2, 12, 0))  # "2024-01-02"
+result4 = normalize_date(None)              # None
+```
+
+**应用场景**：
+- 统一 API 接口日期输入
+- 数据库日期格式规范化
+- 跨系统日期数据交换
 
 ## 五、注意事项
 

--- a/packages/foundation/src/ditto_foundation/util/__init__.py
+++ b/packages/foundation/src/ditto_foundation/util/__init__.py
@@ -1,5 +1,6 @@
-"""IO utility functions."""
+"""工具函数模块."""
 
+from ditto_foundation.util.dates import DateInput, normalize_date
 from ditto_foundation.util.io import atomic_write, file_md5
 
-__all__ = ["atomic_write", "file_md5"]
+__all__ = ["DateInput", "atomic_write", "file_md5", "normalize_date"]

--- a/packages/foundation/src/ditto_foundation/util/dates.py
+++ b/packages/foundation/src/ditto_foundation/util/dates.py
@@ -1,0 +1,42 @@
+"""日期规范化工具函数，将各种日期类型转换为 YYYY-MM-DD 格式."""
+
+from datetime import date, datetime
+
+# 日期输入类型别名
+DateInput = str | date | datetime | None
+
+
+def normalize_date(value: DateInput) -> str | None:
+    """
+    Normalize various date input types to YYYY-MM-DD string format.
+
+    Args:
+        value: Date input (str, date, datetime or None).
+
+    Returns:
+        Normalized date string in YYYY-MM-DD format, or None if input is None.
+
+    Raises:
+        ValueError: If string is not in valid YYYY-MM-DD format.
+
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        # 通过尝试解析来验证字符串格式
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+            return value
+        except ValueError as e:
+            raise ValueError(f"Invalid date format: {value}") from e
+
+    if isinstance(value, datetime):
+        # 将 datetime 转换为日期字符串
+        return value.strftime("%Y-%m-%d")
+
+    if isinstance(value, date):
+        # 格式化 date 对象
+        return value.strftime("%Y-%m-%d")
+
+    raise TypeError(f"Unsupported date type: {type(value)}")


### PR DESCRIPTION
## Summary

- **dates.py 迁移**: 将日期规范化工具从 datahub 迁移至 foundation 包，供所有 ditto 包使用
- **类型注解精确化**: 修复 `failed_checks` 和 `fetchval` 的类型注解，采用务实的类型策略
- **文档更新**: 在 `python-code-style.md` 和 `polars.md` 中添加量化项目类型注解规范

## Changes

### dates.py 迁移 (4 commits)
- 创建 `packages/foundation/src/ditto_foundation/util/dates.py`
- 更新 foundation 和 datahub 的导入导出
- 添加完整测试覆盖

### 类型注解精确化 (2 commits)
- `failed_checks: list[Any]` → `list[DQResult]`
- `fetchval() -> Any` → `str | int | float | None`

### 文档更新 (1 commit)
- **python-code-style.md**: 新增 3.4 节 "DataFrame 驱动系统的类型策略"
  - TypedDict 使用场景对照表
  - 务实类型注解策略（P0-P3 优先级）
  - 类型别名最佳实践
  
- **polars.md**: 新增 "类型安全与 Schema" 章节
  - Polars LazyFrame Plan 阶段类型安全
  - 为什么 TypedDict 在 DataFrame 系统中是反模式
  - Schema 验证和演进策略

## Test Plan

- [x] 269 tests passed (89.20% coverage)
- [x] `pixi run -e dev ci-check` 全部通过
- [x] Pre-commit hooks 验证通过

## Key Insights

在 DataFrame 驱动的量化系统中：
- 数据流向: `SQLite → Polars DataFrame → 向量化运算`
- TypedDict 是冗余的中间层，Polars LazyFrame 在 Plan 阶段就能验证 Schema
- 务实的类型策略：修复真正的 `Any` 问题，保留灵活的 `dict[str, Any]`