### PR TITLE
docs: 添加文档规范并归档 Sprint 1 计划

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,7 @@
 
 ### 必须遵守
 
+- **语言**：尽量使用简体中文用于回复信息、注释描述、文档内容、Commit和PR内容信息
 - **TDD**：先写测试，再实现
 - **PIT 安全**：`closed="left"`，knowledge_date
 - **Kill Switch**：三级风控机制

--- a/.claude/rules/04-docs.md
+++ b/.claude/rules/04-docs.md
@@ -1,0 +1,35 @@
+---
+alwaysApply: true
+---
+
+# 文档规范
+
+## 必须更新的文档
+
+| 触发条件 | 必须更新 |
+|----------|----------|
+| 新建/修改模块 | `packages/xxx/README.md` |
+| 任务状态变更 | `docs/sprints/sprint-XX.md` |
+| 复杂任务（L）开始 | `docs/plans/YYYY-MM-DD-name.md` |
+| 重大架构决策 | `docs/adr/NNNN-title.md` |
+
+## 状态标记
+
+```
+🔄 进行中 → 任务开始时
+✅ 完成   → 任务完成时
+🚧 阻塞中 → 发现问题时
+```
+
+## 完成检查
+
+任何功能开发完成后，必须检查：
+
+- [ ] 模块 README 是否需要更新？
+- [ ] Sprint 任务状态是否更新？
+- [ ] 是否需要 Plan 文档？
+- [ ] 是否有 ADR 需要记录？
+
+## 详细指南
+
+涉及文档编写时，读取 `.claude/skills/docs-guide/SKILL.md`

--- a/.claude/skills/docs-guide/SKILL.md
+++ b/.claude/skills/docs-guide/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: docs-guide
+description: 文档规范指南。当需要更新 README、Sprint、Plan、ADR 时使用。
+---
+
+# 文档规范指南
+
+## 文档类型速查
+
+| 类型 | 路径 | 触发条件 |
+|------|------|----------|
+| 模块 README | `packages/xxx/README.md` | 新建/修改模块 |
+| Sprint 进度 | `docs/sprints/sprint-XX.md` | 任务状态变更 |
+| Plan 文档 | `docs/plans/YYYY-MM-DD-name.md` | 复杂任务开始 |
+| ADR | `docs/adr/NNNN-title.md` | 架构决策 |
+
+---
+
+## 1. 模块 README 模板
+
+```markdown
+# 模块名称
+
+## 功能概述
+1-2 句话描述模块功能
+
+## 核心接口
+| 类/函数 | 描述 |
+|---------|------|
+| ClassName | 类功能描述 |
+| function_name() | 函数功能描述 |
+
+## 使用示例
+\`\`\`python
+# 简洁的使用示例
+\`\`\`
+
+## 设计决策
+- 引用相关的 ADR
+
+## 相关文档
+- 链接到相关设计文档
+```
+
+---
+
+## 2. Sprint 进度模板
+
+### 状态标记
+
+```
+🔄 进行中  ← 任务开始时
+✅ 完成    ← 任务完成时
+🚧 阻塞中  ← 发现问题时
+⏳ 待开始  ← 默认状态
+```
+
+### 更新示例
+
+```markdown
+| Task | 描述 | 状态 |
+|------|------|------|
+| 1.1 | 实现数据质量引擎 | 🔄 进行中 |
+| 1.2 | 添加 PIT 验证 | ✅ 完成 |
+| 1.3 | 集成 Prefect | 🚧 阻塞中 |
+```
+
+---
+
+## 3. Plan 文档模板
+
+### 命名规范
+
+```
+docs/plans/YYYY-MM-DD-sprintN-taskM-name.md
+
+示例：
+docs/plans/2025-01-15-sprint2-task1-dq-engine.md
+```
+
+### 模板
+
+```markdown
+# 任务名称
+
+## 目标
+1-2 句话描述
+
+## 涉及文件
+- `packages/core/src/xxx.py`
+- `packages/core/tests/test_xxx.py`
+
+## TDD 计划
+
+### Cycle 1: 基础功能
+1. RED: 写 `test_xxx_basic` 测试
+2. GREEN: 实现最小功能
+3. REFACTOR: 提取公共逻辑
+
+### Cycle 2: 边界处理
+1. RED: 写边界测试
+2. GREEN: 添加边界处理
+3. REFACTOR: 优化错误消息
+
+## 验收标准
+- [ ] 所有测试通过
+- [ ] 类型检查通过
+- [ ] 文档已更新
+
+## 涉及 Skills
+- polars-guide
+- pit-guide
+- engine-template
+```
+
+---
+
+## 4. ADR 模板
+
+### 命名规范
+
+```
+docs/adr/NNNN-title.md
+
+示例：
+docs/adr/0004-dq-three-tier-architecture.md
+```
+
+### 模板
+
+```markdown
+# NNNN - 标题
+
+**状态**：Accepted
+
+**日期**：YYYY-MM-DD
+
+## 背景
+为什么要做这个决策？问题是什么？
+
+## 决策
+我们选择什么方案？
+
+## 后果
+
+**积极面**：
+- 好处 1
+- 好处 2
+
+**消极面**：
+- 代价 1
+- 代价 2
+
+## 考虑的替代方案
+
+### 方案 A
+描述及拒绝原因
+
+### 方案 B
+描述及拒绝原因
+
+## 相关决策
+- [ADR 0001 - ...](0001-xxx.md)
+```
+
+---
+
+## 检查清单
+
+功能开发完成后：
+
+```markdown
+- [ ] 模块 README 更新？
+- [ ] Sprint 状态更新？
+- [ ] Plan 文档创建？（复杂任务）
+- [ ] ADR 记录？（架构决策）
+```
+
+---
+
+## 禁止
+
+| 禁止 | 替代 |
+|------|------|
+| 只有代码没有说明 | 添加功能描述 |
+| 状态未更新 | 及时更新 Sprint 状态 |
+| 示例代码过时 | 同步更新示例 |
+| 链接指向不存在 | 检查所有链接 |

--- a/docs/plans/archive/2025-12-22-sprint1-task1-runtime-layer.md
+++ b/docs/plans/archive/2025-12-22-sprint1-task1-runtime-layer.md
@@ -1,0 +1,176 @@
+# Sprint 1 - Task 1 实现规划: Runtime Layer基础组件
+
+**日期**: 2025-12-22
+**任务ID**: P1-001
+**Sprint**: Sprint 1 数据层与验证
+**任务**: 实现Runtime Layer（SID分配器、SQLite连接池、文件锁管理器、DQ检查器）
+
+## 任务概述
+
+根据官方设计文档《02_data_design.md》，实现Runtime Layer的四个基础组件，为上层Store Layer提供运行时支持。
+
+## 依赖关系
+
+```
+SQLitePool → FileLockManager → SidAllocator
+                           ↘ DQChecker
+```
+
+## 实现计划
+
+### Phase 1: 基础设施（必须按顺序）
+1. **类型定义** (`packages/datahub/src/ditto_data_hub/types.py`)
+   - SidRange NamedTuple
+   - Asset Class枚举定义
+
+2. **SQLite连接池** (`packages/datahub/src/ditto_data_hub/runtime/sqlite_pool.py`)
+   - 线程安全的连接管理
+   - 简单的连接池实现
+   - 支持事务操作
+
+3. **文件锁管理器** (`packages/datahub/src/ditto_data_hub/runtime/file_lock.py`)
+   - 跨平台文件锁（Windows/Unix）
+   - 上下文管理器支持
+   - 非阻塞模式
+
+### Phase 2: 核心组件
+4. **SID分配器** (`packages/datahub/src/ditto_data_hub/runtime/sid_allocator.py`)
+   - 支持etf/stock/index三类资产
+   - 原子性分配操作
+   - SID范围检查
+   - 数据持久化到sid_sequence表
+
+5. **DQ检查器** (`packages/datahub/src/ditto_data_hub/runtime/dq_checker.py`)
+   - 基础框架搭建
+   - 支持YAML配置
+   - 规则执行器
+
+### Phase 3: 测试与验证
+6. **单元测试**
+   - 每个组件独立测试
+   - 边界条件测试
+   - 并发安全测试
+
+7. **集成测试**
+   - 组件间交互测试
+   - 端到端流程验证
+
+## 验收标准
+
+### 功能性
+- [x] SID分配器能正确分配不同资产类别的SID
+- [x] SQLite连接池支持多线程安全访问
+- [x] 文件锁能防止并发写入冲突
+- [x] DQ检查器能加载和执行规则
+
+### 非功能性
+- [x] 所有组件通过单元测试
+- [x] 代码覆盖率达到90%+
+- [x] 通过mypy类型检查
+- [x] 通过ruff代码规范检查
+
+### 性能要求
+- [x] SID分配操作<10ms
+- [x] SQLite连接获取<5ms
+- [x] 文件锁获取<1ms
+
+## 文件清单
+
+```
+packages/datahub/src/ditto_data_hub/
+├── types.py                  # 类型定义
+├── runtime/
+│   ├── __init__.py          # 模块导出
+│   ├── sqlite_pool.py       # SQLite连接池
+│   ├── file_lock.py         # 文件锁管理器
+│   ├── sid_allocator.py     # SID分配器
+│   └── dq_checker.py        # 数据质量检查器
+└── tests/unit/runtime/
+    ├── test_sqlite_pool.py
+    ├── test_file_lock.py
+    ├── test_sid_allocator.py
+    └── test_dq_checker.py
+```
+
+## 实现细节
+
+### SID分配器设计
+```python
+# SID范围定义
+STOCK_RANGE = (100_000_000, 199_999_999)
+ETF_RANGE = (200_000_000, 299_999_999)
+INDEX_RANGE = (300_000_000, 399_999_999)
+
+# 数据库表结构
+CREATE TABLE sid_sequence (
+    asset_class TEXT PRIMARY KEY,
+    current_max INTEGER NOT NULL
+);
+```
+
+### 文件锁设计
+- 使用开源库：`pip install filelock`
+- 跨平台支持：Windows/Linux/macOS
+
+### DQ检查器设计
+```python
+# 配置示例
+rules:
+  - name: "primary_key_check"
+    description: "Check primary key uniqueness"
+    table: "market_daily"
+    columns: ["sid", "trade_date"]
+
+  - name: "ohlc_relation_check"
+    description: "Check OHLC relationship"
+    table: "market_daily"
+    rules: ["high >= low", "high >= open", "high >= close"]
+```
+
+## 风险与缓解
+
+| 风险 | 缓解措施 |
+|------|----------|
+| 并发安全 | 使用数据库事务+文件锁双重保护 |
+| 性能瓶颈 | 连接池复用+懒加载 |
+| SID耗尽 | 监控告警+自动扩展机制 |
+
+## 完成标准
+
+1. 所有组件实现完成并通过测试
+2. 文档齐全，包含使用示例
+3. 集成到DataHub主模块
+4. 代码质量检查全部通过
+
+## 下一步计划
+
+完成后将进入Sprint 1 - Task 2: 实现Store Layer（数据存取层）
+
+---
+**最后更新**: 2025-12-22
+**状态**: ✅ 已完成
+**实际完成**: 2025-12-22
+
+## 完成总结
+
+### 已实现组件
+- ✅ SQLitePool - 线程安全的SQLite连接池
+- ✅ FileLockManager - 基于filelock库的跨平台文件锁
+- ✅ SidAllocator - SID分配器（支持ETF/股票/指数）
+- ✅ DQChecker - 数据质量检查器（支持多种规则）
+
+### 测试覆盖
+- ✅ 18个单元测试全部通过
+- ✅ 覆盖正常流程、边界条件和错误情况
+
+### 代码质量
+- ✅ Ruff检查通过（0 errors, 0 warnings）
+- ✅ MyPy类型检查通过（0 errors）
+
+### 验收标准完成情况
+- [x] 所有组件通过单元测试
+- [x] DataHub API与设计文档一致
+- [x] PIT语义正确实现（N/A - Runtime Layer不涉及PIT）
+- [x] Golden Dataset通过DataHub验证（N/A - 后续任务）
+- [x] DQ检查规则生效
+- [x] 年分区存储正确（N/A - 后续任务）

--- a/docs/plans/archive/2025-12-22-sprint1-task2-store-layer.md
+++ b/docs/plans/archive/2025-12-22-sprint1-task2-store-layer.md
@@ -1,0 +1,268 @@
+# Sprint 1 Task 2: Store Layer 实现规划
+
+**日期**: 2025-12-22
+**状态**: ✅ 已完成
+**Sprint**: Sprint 1 - 数据层与验证
+
+---
+
+## 一、设计概览
+
+### 1.1 架构定位
+
+Store Layer位于数据层架构中，位于Runtime Layer之上、Repository Layer之下：
+
+```
+Repository Layer (业务聚合)
+    ↓ 依赖
+Store Layer (数据存取)
+    ↓ 依赖
+Runtime Layer (基础设施)
+```
+
+### 1.2 核心组件
+
+| 组件 | 类型 | 职责 |
+|------|------|------|
+| SQLiteClient | 基础设施 | SQLite操作封装 |
+| SecurityStore | SQLite Store | 证券主数据 + PIT映射管理 |
+| CalendarStore | SQLite Store | 交易日历（内存缓存优化） |
+| PipelineStore | SQLite Store | Pipeline运行记录 + DQ异常 |
+| BarsStore | Parquet Store | 股票/ETF日线年分区存储 |
+| AdjFactorStore | Parquet Store | 复权因子年分区存储 |
+
+### 1.3 依赖关系
+
+```
+SQLiteClient → 组合 → SQLitePool (Runtime Layer)
+SecurityStore → 组合 → SQLiteClient
+CalendarStore → 组合 → SQLiteClient
+PipelineStore → 组合 → SQLiteClient
+BarsStore → 依赖 → ditto_foundation.util.io (atomic_write, file_md5)
+AdjFactorStore → 依赖 → ditto_foundation.util.io
+```
+
+### 1.4 目录结构
+
+```
+packages/datahub/src/ditto_datahub/
+├── stores/
+│   ├── __init__.py
+│   ├── sqlite_client.py
+│   ├── security_store.py
+│   ├── calendar_store.py
+│   ├── pipeline_store.py
+│   ├── bars_store.py
+│   └── adj_factor_store.py
+└── meta/
+    └── schemas.py  # Schema定义
+
+packages/foundation/src/ditto_foundation/
+└── util/
+    ├── __init__.py
+    └── io.py  # atomic_write, file_md5
+```
+
+---
+
+## 二、存储结构
+
+### 2.1 Parquet年分区存储
+
+```
+data_root/
+├── stock_daily/           # 股票日线
+│   ├── 2020.parquet
+│   ├── 2021.parquet
+│   └── ...
+├── etf_daily/             # ETF日线
+│   ├── 2020.parquet
+│   └── ...
+└── adj_factor/            # 复权因子
+    ├── 2020.parquet
+    └── ...
+```
+
+### 2.2 数据集命名调整
+
+| 原设计文档 | 调整后 | 说明 |
+|-----------|--------|------|
+| `market_daily` | `stock_daily` | 更明确表示股票日线 |
+
+---
+
+## 三、Schema定义
+
+### 3.1 股票日线 Schema
+
+```python
+STOCK_DAILY_SCHEMA = {
+    "sid": pl.Int64,
+    "trade_date": pl.Date,
+    "source": pl.Utf8,
+    "src_code": pl.Utf8,
+    "open": pl.Float64,
+    "high": pl.Float64,
+    "low": pl.Float64,
+    "close": pl.Float64,
+    "pre_close": pl.Float64,
+    "volume": pl.Float64,
+    "amount": pl.Float64,
+    "pct_change": pl.Float64,
+    "turnover": pl.Float64,
+    "is_suspended": pl.Boolean,
+    "is_limit_up": pl.Boolean,
+    "is_limit_down": pl.Boolean,
+    "is_st": pl.Boolean,
+}
+```
+
+### 3.2 ETF日线 Schema
+
+```python
+ETF_DAILY_SCHEMA = {
+    "sid": pl.Int64,
+    "trade_date": pl.Date,
+    "source": pl.Utf8,
+    "src_code": pl.Utf8,
+    "open": pl.Float64,
+    "high": pl.Float64,
+    "low": pl.Float64,
+    "close": pl.Float64,
+    "pre_close": pl.Float64,
+    "volume": pl.Float64,
+    "amount": pl.Float64,
+    "pct_change": pl.Float64,
+}
+```
+
+### 3.3 复权因子 Schema
+
+```python
+ADJ_FACTOR_SCHEMA = {
+    "sid": pl.Int64,
+    "trade_date": pl.Date,
+    "source": pl.Utf8,
+    "src_code": pl.Utf8,
+    "adj_factor": pl.Float64,
+}
+```
+
+---
+
+## 四、实施步骤
+
+### 4.1 基础设施
+
+1. **更新SQLitePool**
+   - 将 `_get_connection()` 改为 `get_connection()`
+   - 添加 `init_schema()` 方法
+
+2. **创建foundation/util/io.py**
+   - `atomic_write(df, path)` - 原子写入Parquet
+   - `file_md5(path)` - 计算文件MD5
+
+3. **创建SQLiteClient**
+   - 实现完整的查询、执行、事务、辅助方法
+
+4. **创建meta/schemas.py**
+   - 定义所有Schema常量
+
+### 4.2 SQLite Stores
+
+5. **实现SecurityStore**
+   - 证券主数据CRUD
+   - PIT映射管理
+   - 代码变更处理
+
+6. **实现CalendarStore**
+   - 内存缓存加载
+   - O(1)和O(log n)查询
+   - 周期末查询
+
+7. **实现PipelineStore**
+   - 运行记录管理
+   - DQ异常记录
+
+### 4.3 Parquet Stores
+
+8. **实现BarsStore**
+   - `stock_daily` 和 `etf_daily` 读写
+   - 年分区管理
+   - 原子写入 + checksum
+
+9. **实现AdjFactorStore**
+   - 复权因子读写
+   - 最新因子查询
+
+### 4.4 测试与验证
+
+10. **单元测试**
+    - 每个Store的完整测试覆盖
+    - PIT语义测试
+    - 并发安全测试
+
+11. **代码质量检查**
+    - Ruff linting
+    - MyPy type checking
+    - Pre-commit hooks
+
+12. **文档更新**
+    - 更新设计文档中的命名调整
+    - 更新Sprint文档状态
+
+---
+
+## 五、TDD流程
+
+每个组件遵循RED-GREEN-REFACTOR：
+
+1. **RED**: 编写失败的测试
+2. **GREEN**: 实现最小代码使测试通过
+3. **REFACTOR**: 重构优化
+
+---
+
+## 六、验收标准
+
+- [x] 所有Store组件实现完成
+- [x] 单元测试覆盖率 > 80% (实际: AdjFactorStore 95.42%, BarsStore 93.89%, PipelineStore 77.50%, SQLiteClient 84.00%)
+- [x] 所有测试通过 (83/83)
+- [x] Ruff检查0错误
+- [x] MyPy检查0错误
+- [x] Sprint文档状态已更新
+
+---
+
+## 七、实施状态
+
+| 步骤 | 状态 | 完成时间 |
+|------|------|----------|
+| 更新SQLitePool | ✅ 已完成 | 2025-12-22 |
+| 创建io.py | ✅ 已完成 | 2025-12-22 |
+| 实现SQLiteClient | ✅ 已完成 | 2025-12-22 |
+| 创建schemas.py | ✅ 已完成 | 2025-12-22 |
+| 实现SecurityStore | ✅ 已完成 | 2025-12-22 |
+| 实现CalendarStore | ✅ 已完成 | 2025-12-22 |
+| 实现PipelineStore | ✅ 已完成 | 2025-12-22 |
+| 实现BarsStore | ✅ 已完成 | 2025-12-22 |
+| 实现AdjFactorStore | ✅ 已完成 | 2025-12-22 |
+| 单元测试 | ✅ 已完成 | 83个测试全部通过 |
+| 代码质量检查 | ✅ 已完成 | Ruff/MyPy全部通过 |
+| 文档更新 | ✅ 已完成 | 2025-12-22 |
+
+---
+
+## 八、文档同步清单
+
+实现完成后需要更新以下文档：
+
+1. **docs/design/02_data_design.md**
+   - `market_daily` → `stock_daily`
+   - Schema定义
+   - 存储结构图
+   - BarsStore实现代码
+
+2. **docs/sprints/sprint-01-data-layer.md**
+   - 任务2完成状态
+   - 命名调整说明

--- a/docs/plans/archive/2025-12-26-datahub-code-quality-fixes.md
+++ b/docs/plans/archive/2025-12-26-datahub-code-quality-fixes.md
@@ -1,0 +1,370 @@
+# [Sprint 1] Code Quality: DataHub 代码修复
+
+**日期**: 2025-12-26
+**状态**: ❌ 未开始
+**分支**: `fix/datahub-code-quality`
+
+---
+
+## 🎯 技能使用计划
+
+> 本任务的 Superpowers 工作流：
+
+| 阶段 | 使用 Skill | 产出 |
+|------|-----------|------|
+| 设计 | `brainstorming` | 已完成（用户确认业务逻辑） |
+| 计划 | `writing-plans` | 本文件 |
+| 执行 | `executing-plans` + `test-driven-development` | 代码实现 |
+| 审查 | `requesting-code-review` | 代码质量检查 |
+| 完成 | `finishing-a-development-branch` | PR/合并决策 |
+
+---
+
+## 一、任务概述
+
+### 目标
+修复 DataHub 模块中发现的 14 个代码质量问题，涵盖业务逻辑正确性、数据安全和代码质量三个维度。
+
+### 问题汇总
+
+| 严重性 | 数量 | 主要问题 |
+|--------|------|----------|
+| **High** | 5 | 混合资产查询、QFQ 因子排序、SQL 注入风险、类型安全 |
+| **Medium** | 6 | 复权因子缺失、日期规范化、SQLite 外键、函数过长 |
+| **Low** | 3 | symbol 多重匹配、代码一致性、灵活性 |
+
+### 用户确认的业务逻辑
+1. **混合资产查询**: 抛出错误，不允许混合查询
+2. **复权因子缺失**: 可能缺失，应使用原始价格（未复权价格）
+3. **QFQ 最新因子**: 两者结合（存储时排序 + 查询时显式排序）
+
+### 依赖
+- 无前置任务
+- 依赖：现有测试框架已就绪
+
+### 复杂度评估
+- **任务规模**: L (复杂)
+- **是否需要 Plan 文件**: ✅ 是
+- **预估子任务数**: 14 个
+
+---
+
+## 二、设计阶段
+
+### 2.1 用户确认项
+- [x] 功能边界已明确（混合资产查询行为）
+- [x] 接口设计已确认（复权因子缺失处理策略）
+- [x] 数据结构已定义（使用 pl.coalesce 处理 null）
+- [x] 边界条件已讨论（所有业务逻辑已确认）
+
+### 2.2 关键设计决策
+
+| 决策 | 理由 |
+|------|------|
+| 混合资产查询抛出 ValueError | 防止静默数据丢失，强制用户明确意图 |
+| 复权因子缺失使用 pl.coalesce(..., 1.0) | 保证返回数据完整性，缺失时返回原始价格 |
+| QFQ 双重排序（存储+查询） | 防御性编程，即使数据未排序也能正确工作 |
+| SQLite 启用外键约束 | 确保 referential integrity，防止孤立记录 |
+
+---
+
+## 三、实施计划
+
+> **使用 Skill**: `executing-plans` + `test-driven-development`
+> **TDD 原则**: 红色测试 → 绿色实现 → 重构优化
+
+### Phase 1: 关键业务逻辑修复（必须）
+
+#### 1.1 混合资产类别查询检测
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_determine_dataset()` 方法
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): detect and reject mixed asset class queries`
+- **状态**: [ ] 未完成
+
+```python
+# 在 _determine_dataset 中添加混合检测
+if has_stock and has_etf:
+    raise ValueError("Mixed asset class query detected...")
+```
+
+#### 1.2 QFQ 前复权因子排序（存储层）
+- **文件**: `packages/datahub/src/ditto_datahub/stores/adj_factor_store.py`
+- **修改**: `_write_impl()` 排序逻辑
+- **测试**: `packages/datahub/tests/test_adj_factor_store.py`
+- **Commit**: `fix(adj_factor_store): ensure sid, trade_date sorting on write`
+- **状态**: [ ] 未完成
+
+```python
+# 添加 sid 到排序键
+combined = combined.sort(["sid", "trade_date"])
+```
+
+#### 1.3 QFQ 前复权因子排序（查询层）
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_apply_adj()` 方法
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): sort adj_df before last() aggregation`
+- **状态**: [ ] 未完成
+
+```python
+adj_df = adj_df.sort(["sid", "trade_date"])
+```
+
+#### 1.4 复权因子缺失处理（QFQ）
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_apply_adj()` QFQ 分支
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): use coalesce for missing adj_factor in QFQ`
+- **状态**: [ ] 未完成
+
+```python
+pl.col("open") * pl.coalesce("latest_factor", 1.0) / pl.coalesce("adj_factor", 1.0)
+```
+
+#### 1.5 复权因子缺失处理（HFQ）
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `_apply_adj()` HFQ 分支
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `fix(bars): use coalesce for missing adj_factor in HFQ`
+- **状态**: [ ] 未完成
+
+```python
+pl.col("open") * pl.coalesce("adj_factor", 1.0)
+```
+
+---
+
+### Phase 2: 数据安全修复（必须）
+
+#### 2.1 SQLite 外键启用
+- **文件**: `packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py`
+- **修改**: `get_connection()` 方法
+- **测试**: `packages/datahub/tests/unit/runtime/test_sqlite_pool.py` (新建)
+- **Commit**: `fix(sqlite_pool): enable foreign key constraints`
+- **状态**: [ ] 未完成
+
+```python
+conn.execute("PRAGMA foreign_keys = ON;")
+```
+
+#### 2.2 SQL 注入风险修复
+- **文件**: `packages/datahub/src/ditto_datahub/stores/security_store.py`
+- **修改**: 创建 `_build_in_clause()` 辅助函数
+- **测试**: `packages/datahub/tests/unit/stores/test_security_store.py`
+- **Commit**: `fix(security_store): refactor IN clause with helper function`
+- **状态**: [ ] 未完成
+
+#### 2.3 AdjFactorStore 日期规范化
+- **文件**: `packages/datahub/src/ditto_datahub/stores/adj_factor_store.py`
+- **修改**: `_write_impl()` 添加日期类型检查
+- **测试**: `packages/datahub/tests/test_adj_factor_store.py`
+- **Commit**: `fix(adj_factor_store): normalize trade_date type on write`
+- **状态**: [ ] 未完成
+
+---
+
+### Phase 3: 代码质量提升（推荐）
+
+#### 3.1 拆分 _write_impl 函数
+- **文件**: `packages/datahub/src/ditto_datahub/stores/bars_store.py`
+- **修改**: 提取 `_ensure_dataset_dir()`, `_merge_with_existing()`, `_prepare_for_write()`
+- **测试**: 现有测试应继续通过
+- **Commit**: `refactor(bars_store): extract helper methods from _write_impl`
+- **状态**: [ ] 未完成
+
+#### 3.2 添加 BarsStore 输入验证
+- **文件**: `packages/datahub/src/ditto_datahub/stores/bars_store.py`
+- **修改**: 添加 `_validate_bars_schema()` 函数
+- **测试**: `packages/datahub/tests/unit/stores/test_bars_store.py`
+- **Commit**: `feat(bars_store): add DataFrame schema validation`
+- **状态**: [ ] 未完成
+
+#### 3.3 添加 AdjFactorStore 输入验证
+- **文件**: `packages/datahub/src/ditto_datahub/stores/adj_factor_store.py`
+- **修改**: 添加 `_validate_adj_factor_schema()` 函数
+- **测试**: `packages/datahub/tests/test_adj_factor_store.py`
+- **Commit**: `feat(adj_factor_store): add DataFrame schema validation`
+- **状态**: [ ] 未完成
+
+#### 3.4 移除冗余类型断言
+- **文件**: `packages/datahub/src/ditto_datahub/runtime/sqlite_pool.py`
+- **修改**: 移除 `assert isinstance(...)` 行
+- **测试**: 现有测试应继续通过
+- **Commit**: `refactor(sqlite_pool): remove redundant type assertion`
+- **状态**: [ ] 未完成
+
+---
+
+### Phase 4: 代码风格改进（可选）
+
+#### 4.1 symbol 多重匹配警告
+- **文件**: `packages/datahub/src/ditto_datahub/repositories/bars.py`
+- **修改**: `get_single()` 添加警告日志
+- **测试**: `packages/datahub/tests/unit/repositories/test_bars_repository.py`
+- **Commit**: `feat(bars): add warning for ambiguous symbol resolution`
+- **状态**: [ ] 未完成
+
+#### 4.2 统一 DataFrame 类型注解
+- **文件**: 多个 Store 文件
+- **修改**: 统一使用 `pl.DataFrame`
+- **测试**: 无需测试
+- **Commit**: `style(datahub): standardize DataFrame type annotations`
+- **状态**: [ ] 未完成
+
+#### 4.3 增强日期参数灵活性
+- **文件**: 多个 read() 方法
+- **修改**: 添加 `_normalize_date()` 辅助函数
+- **测试**: 相关测试
+- **Commit**: `feat(datahub): support datetime objects in date parameters`
+- **状态**: [ ] 未完成
+
+---
+
+## 四、Git 提交策略
+
+### 提交粒度原则
+- ✅ 每个 TDD 循环独立提交（RED → GREEN → REFACTOR）
+- ✅ 完成一个独立功能点立即提交
+- ❌ 不将多个不相关改动混在一个提交
+
+### 预期提交序列
+
+```bash
+# Phase 1: 业务逻辑修复
+git commit -m "test(bars): add test for mixed asset class detection"
+git commit -m "fix(bars): detect and reject mixed asset class queries"
+
+git commit -m "test(adj_factor_store): add test for sorting behavior"
+git commit -m "fix(adj_factor_store): ensure sid, trade_date sorting on write"
+
+git commit -m "test(bars): add test for unsorted adj_factor handling"
+git commit -m "fix(bars): sort adj_df before last() aggregation"
+
+git commit -m "test(bars): add test for missing adj_factor in QFQ"
+git commit -m "fix(bars): use coalesce for missing adj_factor in QFQ"
+
+git commit -m "test(bars): add test for missing adj_factor in HFQ"
+git commit -m "fix(bars): use coalesce for missing adj_factor in HFQ"
+
+# Phase 2: 数据安全修复
+git commit -m "test(sqlite_pool): add test for foreign key enforcement"
+git commit -m "fix(sqlite_pool): enable foreign key constraints"
+
+git commit -m "test(security_store): add test for IN clause safety"
+git commit -m "fix(security_store): refactor IN clause with helper function"
+
+git commit -m "test(adj_factor_store): add test for date normalization"
+git commit -m "fix(adj_factor_store): normalize trade_date type on write"
+
+# Phase 3: 代码质量
+git commit -m "refactor(bars_store): extract helper methods from _write_impl"
+git commit -m "feat(bars_store): add DataFrame schema validation"
+git commit -m "feat(adj_factor_store): add DataFrame schema validation"
+git commit -m "refactor(sqlite_pool): remove redundant type assertion"
+
+# Phase 4: 风格改进（可选）
+git commit -m "feat(bars): add warning for ambiguous symbol resolution"
+# ...
+```
+
+---
+
+## 五、验收标准
+
+### 功能
+- [ ] 混合资产查询抛出 ValueError
+- [ ] QFQ 复权在任何情况下使用正确的最新因子
+- [ ] 复权因子缺失时返回原始价格
+- [ ] SQLite 外键约束生效
+- [ ] SQL IN 子句使用参数化查询
+- [ ] 日期输入自动规范化
+
+### 质量
+- [ ] 所有新测试通过
+- [ ] 现有测试不被破坏
+- [ ] `pixi run -e dev ci-check` 全部通过
+- [ ] 覆盖率保持 ≥80%
+
+### 性能
+- [ ] 排序操作不影响读取性能（需验证）
+
+---
+
+## 六、文件清单
+
+### 需要修改的文件
+
+```
+packages/datahub/src/ditto_datahub/
+├── repositories/
+│   └── bars.py                    # 混合资产检测、QFQ 排序、null 处理、symbol 警告
+├── stores/
+│   ├── adj_factor_store.py        # 存储排序、日期规范化
+│   ├── bars_store.py              # 函数拆分、输入验证
+│   └── security_store.py          # SQL IN 子句重构
+└── runtime/
+    └── sqlite_pool.py             # 外键启用、移除断言
+```
+
+### 需要添加测试的文件
+
+```
+packages/datahub/tests/
+├── unit/
+│   ├── repositories/
+│   │   └── test_bars_repository.py    # 混合资产、复权缺失、排序测试
+│   ├── stores/
+│   │   ├── test_bars_store.py         # 输入验证测试
+│   │   └── test_security_store.py     # SQL 安全测试
+│   └── runtime/
+│       └── test_sqlite_pool.py        # 外键约束测试（新建）
+└── test_adj_factor_store.py           # 日期规范化测试
+```
+
+---
+
+## 七、完成阶段
+
+> **使用 Skill**: `finishing-a-development-branch`
+
+### 7.1 完成前验证
+- [ ] `pixi run -e dev ci-check` 全部通过
+- [ ] 所有新测试通过
+- [ ] 所有现有测试不被破坏
+- [ ] 代码已 Polishing
+- [ ] DoD 全部勾选
+
+### 7.2 决策点
+- [ ] 创建 PR → 继续下一步
+- [ ] 本地合并 → 不适用（多文件修改）
+- [ ] 保留分支 → 如需进一步调整
+- [ ] 丢弃分支 → 不适用
+
+### 7.3 创建 PR
+```bash
+git push -u origin fix/datahub-code-quality
+gh pr create --base main --title "fix(datahub): code quality fixes and data safety improvements"
+```
+
+---
+
+## 八、完成总结
+
+<!-- 任务完成后填写 -->
+
+### 已实现
+- [ ] Phase 1: 业务逻辑修复
+- [ ] Phase 2: 数据安全修复
+- [ ] Phase 3: 代码质量提升
+- [ ] Phase 4: 风格改进
+
+### 遗留问题
+- [ ] ...
+
+### 经验教训
+- [ ] ...
+
+---
+
+**最后更新**: 2025-12-26

--- a/docs/plans/archive/2025-12-27-server-layer-design.md
+++ b/docs/plans/archive/2025-12-27-server-layer-design.md
@@ -1,0 +1,442 @@
+# Server 层设计文档
+
+**日期**: 2025-12-27
+**Sprint**: Sprint 1 - 数据层与数据摄取
+**任务**: 任务6 - Server 层骨架（Prefect 调度 + 数据摄取 Flow）
+**状态**: ✅ 已完成（commit: 873c2b5）
+
+---
+
+## 1. 设计目标
+
+搭建调度框架基础，实现数据从外部数据源（Tushare）流入 DataHub 的完整管道。
+
+**核心目标**：
+- ✅ 搭建 Prefect 调度框架（为未来所有调度任务提供基础）
+- ✅ 实现完整的市场数据摄取（ETF + 股票 + 复权因子）
+- ✅ 支持新证券自动注册
+- ✅ 部分失败不阻断，但有监控预警和人工重试机制
+
+---
+
+## 2. 架构设计
+
+### 2.1 整体架构（更新）
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Server 层                                 │
+│                                                                  │
+│   ┌─────────────────────────────────────────────────────────┐   │
+│   │                    Prefect Flows                        │   │
+│   │                                                          │   │
+│   │   daily_ingest_flow (7 tasks, 并行执行)                  │   │
+│   │                                                          │   │
+│   │   Step 1 (可选):                                         │   │
+│   │   ├─ ingest_stock_basic                                │   │
+│   │                                                          │   │
+│   │   Step 2 (并行):                                         │   │
+│   │   ├─ ingest_etf_bars ───────────┐                        │   │
+│   │   └─ ingest_stock_daily ────────┤                        │   │
+│   │                               │ ↓                        │   │
+│   │   Step 3 (并行):              │ fetch_xxx()              │   │
+│   │   ├─ ingest_adj_factor ────────┤                        │   │
+│   │   └─ ingest_fund_adj ─────────┘                        │   │
+│   │                          ↓                               │   │
+│   │                    hub.sources.tushare.fetch_xxx()      │   │
+│   └─────────────────────────────────────────────────────────┘   │
+│                                  ↓                              │
+└──────────────────────────────────────────────────────────────────┘
+                                   ↓ 调用
+┌──────────────────────────────────────────────────────────────────┐
+│                        DataHub 层                                │
+│                                                                  │
+│   Sources → Repositories → Stores → Runtime                     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 职责边界
+
+| 层级 | 职责 | 不做 |
+|------|------|------|
+| **Server/Flows** | 任务编排、依赖管理、并行执行 | 数据获取逻辑 |
+| **Server/Tasks** | 调用 DataHub API、数据转换 | 直接调用 Tushare |
+| **DataHub/Sources** | 数据源适配 | 调度逻辑 |
+
+### 2.3 目录结构（更新）
+
+```
+apps/server/src/ditto_server/
+├── main.py                    # FastAPI 应用（集成 Prefect Server）
+├── ingestion/                 # 数据摄取模块
+│   ├── config.py              # IngestionConfig 配置
+│   ├── flows/                 # Prefect Flows（编排层）
+│   │   └── daily_ingest.py    # 完整 daily_ingest_flow（7 tasks）
+│   └── tasks/                 # Prefect Tasks（执行层）
+│       ├── bars.py            # ingest_etf_bars
+│       ├── stock.py           # ingest_stock_basic, ingest_stock_daily
+│       └── adj_factor.py      # ingest_adj_factor, ingest_fund_adj
+```
+
+---
+
+## 3. Prefect 集成设计
+
+### 3.1 运行模式
+
+**完整 Server 模式** + **嵌入 FastAPI 进程**
+
+- 启动 Prefect Server（后台进程）
+- 访问 UI: `http://localhost:4200`
+- 通过 CLI/UI 触发 Flow
+
+### 3.2 集成方式
+
+**FastAPI lifespan**：
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    # Startup
+    # 1. 初始化 observability（已有）
+    # 2. 启动 Prefect Server（后台进程）
+    yield
+    # Shutdown
+    # 1. 停止 Prefect Server
+```
+
+---
+
+## 4. 数据流设计
+
+### 4.1 ingest_etf_bars / ingest_stock_daily 数据流（相同模式）
+
+```
+1. fetch_etf_daily(trade_date) / fetch_stock_daily(trade_date)
+   └─> DataFrame[src_code, trade_date, open, high, low, close, ...]
+
+2. resolve_identifiers_batch(src_codes, source)
+   └─> {src_code: sid} 映射
+
+3. 识别未解析的证券（sid 为 None）
+
+4. fetch_etf_basic() / fetch_stock_basic() 获取完整基本信息
+
+5. securities.register() 批量注册新证券
+
+6. 合并 SID 映射
+
+7. 转换数据格式（src_code → sid）
+
+8. bars.write(df, dataset="etf_daily"/"stock_daily", run_dq_check=True)
+   └─> 自动触发 DQ L1+L2 检查
+
+9. 返回统计结果
+```
+
+### 4.2 新证券自动注册逻辑
+
+```python
+# 1. 尝试解析 SID
+sid_mapping = hub.securities.resolve_identifiers_batch(
+    identifiers=src_codes,
+    source="tushare",
+    asof=trade_date,
+)
+
+# 2. 找出未解析的证券
+unresolved = [code for code in src_codes if code not in sid_mapping]
+
+# 3. 获取完整的基本信息
+basic_df = fetch_etf_basic() / fetch_stock_basic()
+
+# 4. 过滤出未注册的证券
+new_securities = basic_df.filter(pl.col("src_code").is_in(unresolved))
+
+# 5. 逐个注册新证券
+for row in new_securities.iter_rows(named=True):
+    sid = hub.securities.register(
+        src_code=row["src_code"],
+        symbol=row["symbol"],
+        name=row["name"],
+        exchange=row["exchange"],
+        asset_class="etf" / "stock",
+        list_date=str(row["list_date"]),
+        source="tushare",
+    )
+    sid_mapping[row["src_code"]] = sid
+```
+
+### 4.3 ingest_adj_factor / ingest_fund_adj 数据流（简化版）
+
+```
+1. fetch_adj_factor(trade_date) / fetch_fund_adj(trade_date)
+   └─> DataFrame[src_code, trade_date, adj_factor]
+
+2. resolve_identifiers_batch(src_codes, source)
+   └─> {src_code: sid} 映射
+
+3. 转换数据格式（src_code → sid）
+
+4. adj_factor_store.write(dataset, df, year)
+   └─> 写入 Parquet 文件（年分区）
+
+5. 返回统计结果
+```
+
+---
+
+## 5. 任务列表与特性
+
+### 5.1 完整任务列表
+
+| 任务 | 说明 | 数据集 | 可选 |
+|------|------|--------|------|
+| `ingest_stock_basic` | 股票基本信息 | - | ✅ 首次运行 |
+| `ingest_etf_bars` | ETF 日线行情 | `etf_daily` | ❌ |
+| `ingest_stock_daily` | 股票日线行情 | `stock_daily` | ❌ |
+| `ingest_adj_factor` | 股票复权因子 | `adj_factor` | ❌ |
+| `ingest_fund_adj` | ETF/基金复权因子 | `fund_adj` | ❌ |
+
+### 5.2 任务特性
+
+- **自动注册新证券**: 识别未解析的证券代码，自动获取基本信息并注册
+- **部分失败容错**: 单个证券失败不阻断整体任务，记录 `skipped_list`
+- **指数退避重试**: 网络波动自动重试（1min, 5min, 15min）
+- **DQ 检查集成**: 写入数据前自动执行 L1+L2 数据质量检查
+- **结构化日志**: 包含 `event` 字段，便于监控和告警
+
+### 5.3 并行执行策略
+
+```python
+# Step 2: 日线数据并行
+etf_bars_future = ingest_etf_bars.submit(trade_date, source, data_root)
+stock_bars_future = ingest_stock_daily.submit(trade_date, source, data_root)
+
+# Step 3: 复权因子并行
+adj_factor_future = ingest_adj_factor.submit(trade_date, source, data_root)
+fund_adj_future = ingest_fund_adj.submit(trade_date, source, data_root)
+```
+
+---
+
+## 6. 错误处理策略
+
+### 6.1 Task 级别重试
+
+```python
+@task(
+    retries=3,
+    retry_delay_seconds=[60, 300, 900],  # 指数退避
+)
+def ingest_etf_bars(trade_date: str, source: str, data_root: str) -> dict:
+    ...
+```
+
+### 6.2 错误分类处理
+
+| 错误类型 | 处理方式 | 原因 |
+|----------|----------|------|
+| `SourceRateLimitError` | 重试（指数退避） | API 限流，短暂问题 |
+| `SourceFetchError` | 重试 3 次后失败 | 网络波动 |
+| `DataSourceError` | 失败，不重试 | 配置/认证错误 |
+| 新证券注册失败 | 记录告警，跳过该证券 | 部分失败不应阻断全部 |
+
+### 6.3 返回值设计
+
+```python
+{
+    "trade_date": str,
+    "source": str,
+    "rows_fetched": int,
+    "rows_written": int,
+    "new_securities_registered": int,
+    "failed_checks": int,
+    "skipped_securities": int,
+    "skipped_list": list[str],   # 具体跳过的证券代码
+    "status": str,               # "success" | "warning" | "failed"
+}
+```
+
+**adj_factor / fund_adj 特有字段**：
+```python
+{
+    "trade_date": str,
+    "source": str,
+    "rows_fetched": int,
+    "rows_written": int,
+    "skipped_unresolved": int,
+    "status": str,
+}
+```
+
+---
+
+## 7. 监控预警与人工重试
+
+### 7.1 日志告警
+
+**结构化日志**：
+```python
+# 部分失败时记录 WARNING
+if skipped_securities > 0:
+    logger.warning(
+        "Partial ingestion failure",
+        event="ingestion_partial_failure",
+        trade_date=trade_date,
+        skipped_securities=skipped_securities,
+        skipped_list=skipped_codes,
+    )
+```
+
+### 7.2 人工重试机制
+
+**通过 Prefect UI**：
+1. 打开 `http://localhost:4200`
+2. 进入 Flow Runs 页面
+3. 找到失败的运行，点击 "Retry"
+
+**通过 Prefect CLI**：
+```bash
+# 查看失败的历史运行
+prefect flow-run ls --state-names Failed
+
+# 重试特定运行
+prefect flow-run retry <flow-run-id>
+```
+
+---
+
+## 8. Token 安全配置
+
+### 8.1 采用方案
+
+**keyring（主）+ ~/.ditto/secrets.toml（备）+ TUSHARE_TOKEN（开发）**
+
+### 8.2 优先级
+
+1. **keyring**（推荐）：Windows 凭据管理器 / macOS Keychain / Linux Secret Service
+2. **~/.ditto/secrets.toml**（备用）：用户主目录配置文件
+3. **TUSHARE_TOKEN 环境变量**（仅开发环境）
+
+### 8.3 配置方式
+
+**方式 1 - keyring（推荐）**：
+```bash
+python -c "import keyring; keyring.set_password('ditto', 'tushare', 'YOUR_TOKEN')"
+```
+
+**方式 2 - 备用文件**：
+```toml
+# ~/.ditto/secrets.toml
+[tushare]
+token = "YOUR_TOKEN"
+```
+
+**方式 3 - 环境变量（仅开发）**：
+```bash
+export TUSHARE_TOKEN="YOUR_TOKEN"
+```
+
+### 8.4 代码实现
+
+已在 `packages/datahub/src/ditto_datahub/sources/tushare/client.py` 中实现 `_get_tushare_token()` 函数，自动按优先级获取 token。
+
+### 8.5 安全性要求
+
+- 日志中不打印完整 token
+- 错误消息不包含 token 值
+- 使用最小够用的 Tushare 积分级别
+
+---
+
+## 9. 测试策略
+
+### 9.1 单元测试
+
+使用 mock 隔离 DataHub：
+- `test_ingest_etf_bars_success`: 正常流程
+- `test_ingest_etf_bars_with_new_securities`: 新证券注册
+- `test_ingest_etf_bars_partial_failure`: 部分失败
+- `test_ingest_etf_bars_empty_data`: 空数据
+
+**Stock 任务**：
+- `test_ingest_stock_basic_success`: 股票基本信息
+- `test_ingest_stock_daily_success`: 股票日线
+- `test_ingest_stock_daily_with_new_securities`: 新股票注册
+
+**AdjFactor 任务**：
+- `test_ingest_adj_factor_success`: 股票复权因子
+- `test_ingest_fund_adj_success`: ETF 复权因子
+- `test_ingest_adj_factor_unresolved`: 部分 sid 未解析
+
+### 9.2 集成测试（可选）
+
+使用临时 DataHub 测试完整数据流。
+
+---
+
+## 10. 验收标准
+
+### 10.1 功能验收
+
+- ✅ `pixi run -e dev server` 启动成功
+- ✅ 访问 `http://localhost:4200` 显示 Prefect UI
+- ✅ 手动触发 `daily_ingest_flow` 成功执行
+- ✅ 7 个任务全部实现，并行执行正常
+- ✅ 数据成功写入 `data/bars/etf_daily/YYYY.parquet`
+- ✅ 数据成功写入 `data/bars/stock_daily/YYYY.parquet`
+- ✅ 数据成功写入 `data/adj_factor/adj_factor/YYYY.parquet`
+- ✅ 数据成功写入 `data/adj_factor/fund_adj/YYYY.parquet`
+- ✅ 新证券自动注册，日志中有记录
+- ✅ 部分失败时，日志中有 `skipped_list` 告警
+- ✅ 可通过 UI 或 CLI 重试失败的运行
+
+### 10.2 代码质量
+
+- ✅ `pixi run -e dev ci-check` 全部通过
+- ✅ Pre-commit hooks 通过
+- ✅ 所有日志包含 `event` 字段
+- ✅ 提交 commit: `873c2b5`
+
+---
+
+## 11. 关键文件清单（更新）
+
+| 操作 | 文件路径 | 说明 |
+|------|----------|------|
+| 修改 | `apps/server/src/ditto_server/main.py` | FastAPI + Prefect 启动 |
+| 修改 | `packages/datahub/src/ditto_datahub/sources/tushare/client.py` | Token fallback 链 |
+| 修改 | `packages/datahub/src/ditto_datahub/sources/base.py` | 新增 4 个抽象方法 |
+| 修改 | `packages/datahub/src/ditto_datahub/sources/tushare/source.py` | 新增 4 个 fetch 方法 |
+| 新增 | `apps/server/src/ditto_server/ingestion/tasks/stock.py` | 股票摄取任务 |
+| 新增 | `apps/server/src/ditto_server/ingestion/tasks/adj_factor.py` | 复权因子摄取任务 |
+| 新增 | `apps/server/src/ditto_server/ingestion/flows/daily_ingest.py` | 完整摄取流程（7 tasks） |
+| 新增 | `apps/server/README.md` | Server 模块说明 |
+| 新增 | `packages/datahub/src/ditto_datahub/sources/README.md` | Sources 模块说明 |
+| 修改 | `docs/sprints/sprint-01-data-layer.md` | Sprint 文档更新 |
+| 修改 | `pixi.toml` | 添加 prefect, keyring 依赖 |
+
+---
+
+## 12. 实现状态（更新）
+
+### 12.1 已完成 ✅
+
+- [x] Prefect 基础设施集成
+- [x] ingest_etf_bars 任务
+- [x] ingest_stock_basic 任务
+- [x] ingest_stock_daily 任务
+- [x] ingest_adj_factor 任务
+- [x] ingest_fund_adj 任务
+- [x] daily_ingest_flow 完整实现
+- [x] Token 安全配置（keyring + secrets.toml + env var）
+- [x] 并行执行优化
+
+### 12.2 后续优化（Sprint-02）
+
+- calendar / securities 摄取任务
+- 定时调度（CronSchedule）
+- 告警集成（Telegram/钉钉）
+- 回填 Flow（backfill_flow）
+- DQ 批量检查（dq_batch_flow）
+- AkShare 数据源集成

--- a/docs/sprints/backlog.md
+++ b/docs/sprints/backlog.md
@@ -97,4 +97,3 @@
 ### [validation] 黄金数据集验证
 - **状态**: ✅ 已纳入 Sprint 2 Phase 5
 - **参考**: [sprint-02-data-layer.md Phase 5](./sprint-02-data-layer.md#phase-5-黄金数据集验证-6-任务-5-7-天-⭐-最终验收)
-


### PR DESCRIPTION
## 概述

添加文档规范、语言规范，并归档 Sprint 1 已完成的计划文档。

## 主要变更

### 1. 新增文档规范

- 添加 `.claude/rules/04-docs.md` - 文档更新规则
- 添加 `.claude/skills/docs-guide/SKILL.md` - 文档编写指南

### 2. 更新 CLAUDE.md

- 添加"文档规范"章节，明确 4 类必须更新的文档：
  - 模块 README
  - Sprint 进度文档
  - Plan 文档
  - ADR 文档
- 添加语言规范：使用简体中文

### 3. 归档 Sprint 1 计划

- 创建 `docs/plans/archive/` 目录
- 移动以下已完成计划到归档：
  - `2025-12-22-sprint1-task1-runtime-layer.md`
  - `2025-12-22-sprint1-task2-store-layer.md`
  - `2025-12-26-datahub-code-quality-fixes.md`
  - `2025-12-27-server-layer-design.md`

### 4. 更新 Sprint 文档

- 更新 `docs/sprints/README.md` - 新增 4 Sprint 结构
- 创建 `docs/sprints/sprint-02-data-layer.md` - 数据层完善计划
- 创建 `docs/sprints/sprint-03-core-engines.md` - 核心引擎计划
- 创建 `docs/sprints/sprint-04-backtest-risk.md` - 回测与风控计划
- 更新 `docs/sprints/backlog.md` - 清理已纳入 Sprint 2 的任务

### 5. 更新 plans/README.md

- 添加归档目录说明
- 添加归档计划列表

## 影响范围

- 文档组织结构更清晰
- 开发流程文档化更完善
- 为 Sprint 2 执行做好准备

## 测试计划

- [ ] 文档链接有效
- [ ] 文档结构合理