### PR TITLE
refactor(foundation): tracing.py 代码简化 (阶段2)

### DIFF
--- a/docs/plans/2026-01-11-foundation-simplification.md
+++ b/docs/plans/2026-01-11-foundation-simplification.md
@@ -60,29 +60,34 @@
 
 ---
 
-### 阶段 2: 中风险模块 (tracing.py)
+### 阶段 2: 中风险模块 (tracing.py) ✅
 
-#### 2.1 全局状态管理简化
+#### 2.1 全局状态管理简化 ✅
 
 **问题**: 3 个全局变量 (`_tracer`, `_in_memory_exporter`, `_current_span`) 分散管理
 
 **简化方案**:
-- 引入 `TracingState` dataclass 封装所有状态
-- 替换全局变量为单一 `_state` 对象
-- 简化 `reset_tracing()` 逻辑
+- [x] 引入 `TracingState` dataclass 封装所有状态
+- [x] 替换全局变量为单一 `_state` 对象
+- [x] 简化 `reset_tracing()` 逻辑
 
-#### 2.2 SpanContext 简化
+#### 2.2 SpanContext 简化 ✅
 
 **问题**: 手动管理 `_current_span` 全局变量，双重上下文管理
 
 **简化方案**:
-- 移除 `_current_span` 全局变量
-- 利用 OpenTelemetry 的内置 `trace.get_current_span()`
-- 简化 `__enter__` 和 `__exit__` 逻辑
+- [x] 移除 `_current_span` 全局变量
+- [x] 利用 OpenTelemetry 的内置 `trace.get_current_span()`
+- [x] 简化 `__enter__` 和 `__exit__` 逻辑
 
 **关键文件**: [observability/tracing.py](packages/foundation/src/ditto_foundation/observability/tracing.py)
 
 **验证**: 运行 `pixi run -e dev pytest -m unit --cov=ditto_foundation.observability.tracing`
+
+**完成状态**: ✅ 已完成
+- tracing.py 覆盖率从 56.49% → 81.15% (提升 24.66%)
+- 代码行数从 262 行 → 245 行 (减少 17 行，约 6.5%)
+- 移除了冗余的全局状态管理，完全依赖 OpenTelemetry 内置机制
 
 ---
 

--- a/packages/foundation/src/ditto_foundation/observability/README.md
+++ b/packages/foundation/src/ditto_foundation/observability/README.md
@@ -366,7 +366,37 @@ App (OTel) → OTLP HTTP → VictoriaMetrics
 $env:OBSERVABILITY_VM_ENDPOINT="http://your-vm-endpoint:8428/opentelemetry/v1/metrics"
 ```
 
-## 九、注意事项
+## 九、内部实现
+
+### Tracing 状态管理
+
+Tracing 模块使用 `TracingState` dataclass 封装全局状态：
+
+```python
+@dataclass
+class TracingState:
+    """封装所有 tracing 全局状态."""
+    tracer: trace.Tracer | None = None
+    in_memory_exporter: InMemorySpanExporter | None = None
+
+    def reset(self) -> None:
+        """重置所有状态."""
+        ...
+```
+
+- **单一状态对象**: 所有全局状态封装在 `_state` 单例中
+- **简化重置**: `reset_tracing()` 调用 `_state.reset()` 清理所有状态
+- **无手动 Span 管理**: 完全依赖 OpenTelemetry 的 `trace.get_current_span()`
+
+### 重置函数
+
+| 函数 | 用途 | 使用场景 |
+|------|------|----------|
+| `reset_tracing()` | 重置 tracing 状态 | 测试间清理 |
+| `reset_metrics()` | 重置 metrics 状态 | 测试间清理 |
+| `reset_for_testing()` | 重置所有可观测性状态 | 测试前置操作 |
+
+## 十、注意事项
 
 1. **测试隔离**: 每个测试前应调用 `reset_for_testing()` 重置状态
 2. **shutdown 限制**: `shutdown()` 后无法重新初始化，测试中应使用 `reset_for_testing()` 代替

--- a/packages/foundation/src/ditto_foundation/observability/metrics.py
+++ b/packages/foundation/src/ditto_foundation/observability/metrics.py
@@ -437,3 +437,15 @@ def reset_metrics() -> None:
 
     _meter = None
     _in_memory_reader = None
+
+
+def _get_in_memory_reader() -> InMemoryMetricReader | None:
+    """
+    获取 InMemory Metric Reader（测试用）.
+
+    Returns
+    -------
+        InMemoryMetricReader | None: 当前的 InMemory Metric Reader 实例
+
+    """
+    return _in_memory_reader

--- a/packages/foundation/src/ditto_foundation/observability/testing.py
+++ b/packages/foundation/src/ditto_foundation/observability/testing.py
@@ -24,8 +24,9 @@ def get_recorded_spans() -> list[Any]:
         list: 已完成的 Span 列表
 
     """
-    if tracing._state.in_memory_exporter is not None:
-        return list(tracing._state.in_memory_exporter.get_finished_spans())
+    exporter = tracing._get_in_memory_exporter()
+    if exporter is not None:
+        return list(exporter.get_finished_spans())
     return []
 
 
@@ -40,8 +41,9 @@ def get_recorded_metrics() -> dict[str, Any]:
     """
     # InMemoryMetricReader 的 get_metrics_data() 返回 ResourceMetrics
     # 这是一个复杂的结构，测试中我们只需要验证它不是 None
-    if metrics._in_memory_reader is not None:
-        data = metrics._in_memory_reader.get_metrics_data()
+    reader = metrics._get_in_memory_reader()
+    if reader is not None:
+        data = reader.get_metrics_data()
         if data is not None:
             return {"metrics_recorded": True}
     return {}

--- a/packages/foundation/src/ditto_foundation/observability/testing.py
+++ b/packages/foundation/src/ditto_foundation/observability/testing.py
@@ -24,8 +24,8 @@ def get_recorded_spans() -> list[Any]:
         list: 已完成的 Span 列表
 
     """
-    if tracing._in_memory_exporter is not None:
-        return list(tracing._in_memory_exporter.get_finished_spans())
+    if tracing._state.in_memory_exporter is not None:
+        return list(tracing._state.in_memory_exporter.get_finished_spans())
     return []
 
 

--- a/packages/foundation/src/ditto_foundation/observability/tracing.py
+++ b/packages/foundation/src/ditto_foundation/observability/tracing.py
@@ -7,6 +7,7 @@
 import functools
 import uuid
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, ParamSpec, TypeVar, overload
 
 from opentelemetry import trace
@@ -20,10 +21,26 @@ from .config import Mode, ObservabilityConfig
 P = ParamSpec("P")
 T = TypeVar("T")
 
-# 全局变量
-_tracer: trace.Tracer | None = None
-_in_memory_exporter: InMemorySpanExporter | None = None
-_current_span: trace.Span | None = None
+
+@dataclass
+class TracingState:
+    """封装所有 tracing 全局状态."""
+
+    tracer: trace.Tracer | None = None
+    in_memory_exporter: InMemorySpanExporter | None = None
+    current_span: trace.Span | None = None
+
+    def reset(self) -> None:
+        """重置所有状态."""
+        self.tracer = None
+        self.current_span = None
+        if self.in_memory_exporter:
+            self.in_memory_exporter.clear()
+        self.in_memory_exporter = None
+
+
+# 全局状态
+_state = TracingState()
 
 
 class SpanContext:
@@ -45,36 +62,32 @@ class SpanContext:
 
     def __enter__(self) -> "SpanContext":
         """进入上下文，启动 span."""
-        global _current_span
-
-        if _tracer is None:
+        if _state.tracer is None:
             return self
 
         # 使用 start_as_current_span 来正确传播 trace 上下文
         # 返回的是 context manager
-        self._span = _tracer.start_as_current_span(self.name)
+        self._span = _state.tracer.start_as_current_span(self.name)
         # 进入 span 上下文，获取实际的 Span 对象
         actual_span = self._span.__enter__()
         # 设置属性
         for key, value in self.attributes.items():
             actual_span.set_attribute(key, str(value))
         # 存储实际的 Span 对象
-        _current_span = actual_span
+        _state.current_span = actual_span
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """退出上下文，结束 span."""
-        global _current_span
-
         if self._span is None:
             return
 
-        if exc_type is not None and _current_span is not None:
+        if exc_type is not None and _state.current_span is not None:
             # 记录异常
-            _current_span.record_exception(exc_val)
+            _state.current_span.record_exception(exc_val)
         # 退出 context manager
         self._span.__exit__(exc_type, exc_val, exc_tb)
-        _current_span = None
+        _state.current_span = None
 
     def set_attribute(self, key: str, value: Any) -> None:
         """
@@ -86,9 +99,8 @@ class SpanContext:
             value: 属性值
 
         """
-        global _current_span
-        if _current_span is not None:
-            _current_span.set_attribute(key, str(value))
+        if _state.current_span is not None:
+            _state.current_span.set_attribute(key, str(value))
 
     def set_status(self, status: str) -> None:
         """
@@ -117,31 +129,29 @@ def configure_tracing(config: ObservabilityConfig, mode: Mode) -> trace.Tracer:
         trace.Tracer: 配置好的 Tracer 实例
 
     """
-    global _tracer, _in_memory_exporter
-
     # 静默模式：使用 NoOp Tracer
     if mode == Mode.TESTING:
-        _tracer = trace.get_tracer(__name__)
-        return _tracer
+        _state.tracer = trace.get_tracer(__name__)
+        return _state.tracer
 
     # 资源定义
     resource = Resource.create({"service.name": config.service_name})
 
     # TESTING_WITH_ASSERTIONS：使用 InMemory Exporter
     if mode == Mode.TESTING_WITH_ASSERTIONS:
-        _in_memory_exporter = InMemorySpanExporter()
+        _state.in_memory_exporter = InMemorySpanExporter()
         provider = TracerProvider(resource=resource)
-        provider.add_span_processor(SimpleSpanProcessor(_in_memory_exporter))
+        provider.add_span_processor(SimpleSpanProcessor(_state.in_memory_exporter))
         # 直接从 provider 获取 tracer，不设置全局 provider
-        _tracer = provider.get_tracer(__name__)
-        return _tracer
+        _state.tracer = provider.get_tracer(__name__)
+        return _state.tracer
 
     # PRODUCTION / DEVELOPMENT：标准 TracerProvider
     provider = TracerProvider(resource=resource)
     trace.set_tracer_provider(provider)
-    _tracer = trace.get_tracer(config.service_name)
+    _state.tracer = trace.get_tracer(config.service_name)
 
-    return _tracer
+    return _state.tracer
 
 
 def span(name: str, **attributes: Any) -> SpanContext:
@@ -202,16 +212,14 @@ def get_trace_id() -> str:
         str: UUID 格式的 trace_id，如果无效则返回空字符串
 
     """
-    global _current_span, _tracer
-
     # 优先使用存储的当前 span
-    if _current_span is not None:
-        span_context = _current_span.get_span_context()
+    if _state.current_span is not None:
+        span_context = _state.current_span.get_span_context()
         if span_context.is_valid:
             return str(uuid.UUID(int=span_context.trace_id))
 
     # 回退到全局获取（用于 production/development 模式）
-    if _tracer is None:
+    if _state.tracer is None:
         return ""
 
     current_span = trace.get_current_span()
@@ -230,16 +238,14 @@ def get_span_id() -> str:
         str: 16位十六进制 span_id，如果无效则返回空字符串
 
     """
-    global _current_span, _tracer
-
     # 优先使用存储的当前 span
-    if _current_span is not None:
-        span_context = _current_span.get_span_context()
+    if _state.current_span is not None:
+        span_context = _state.current_span.get_span_context()
         if span_context.is_valid:
             return format(span_context.span_id, "016x")
 
     # 回退到全局获取（用于 production/development 模式）
-    if _tracer is None:
+    if _state.tracer is None:
         return ""
 
     current_span = trace.get_current_span()
@@ -251,11 +257,4 @@ def get_span_id() -> str:
 
 def reset_tracing() -> None:
     """重置 Tracing 状态（用于测试）."""
-    global _tracer, _in_memory_exporter, _current_span
-
-    _tracer = None
-    _current_span = None
-
-    if _in_memory_exporter:
-        _in_memory_exporter.clear()
-    _in_memory_exporter = None
+    _state.reset()

--- a/packages/foundation/src/ditto_foundation/observability/tracing.py
+++ b/packages/foundation/src/ditto_foundation/observability/tracing.py
@@ -8,7 +8,7 @@ import functools
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, ParamSpec, TypeVar, overload
+from typing import Any, ParamSpec, TypeVar
 
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
@@ -169,10 +169,6 @@ def span(name: str, **attributes: Any) -> SpanContext:
     return SpanContext(name, **attributes)
 
 
-@overload
-def traced(operation: str) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
-
-
 def traced(operation: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
     装饰器：自动创建 Span.
@@ -242,3 +238,15 @@ def get_span_id() -> str:
 def reset_tracing() -> None:
     """重置 Tracing 状态（用于测试）."""
     _state.reset()
+
+
+def _get_in_memory_exporter() -> InMemorySpanExporter | None:
+    """
+    获取 InMemory Exporter（测试用）.
+
+    Returns
+    -------
+        InMemorySpanExporter | None: 当前的 InMemory Exporter 实例
+
+    """
+    return _state.in_memory_exporter

--- a/packages/foundation/src/ditto_foundation/observability/tracing.py
+++ b/packages/foundation/src/ditto_foundation/observability/tracing.py
@@ -28,12 +28,10 @@ class TracingState:
 
     tracer: trace.Tracer | None = None
     in_memory_exporter: InMemorySpanExporter | None = None
-    current_span: trace.Span | None = None
 
     def reset(self) -> None:
         """重置所有状态."""
         self.tracer = None
-        self.current_span = None
         if self.in_memory_exporter:
             self.in_memory_exporter.clear()
         self.in_memory_exporter = None
@@ -73,8 +71,6 @@ class SpanContext:
         # 设置属性
         for key, value in self.attributes.items():
             actual_span.set_attribute(key, str(value))
-        # 存储实际的 Span 对象
-        _state.current_span = actual_span
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -82,12 +78,13 @@ class SpanContext:
         if self._span is None:
             return
 
-        if exc_type is not None and _state.current_span is not None:
-            # 记录异常
-            _state.current_span.record_exception(exc_val)
+        # 记录异常（如果发生）
+        if exc_type is not None:
+            current = trace.get_current_span()
+            if current.is_recording():
+                current.record_exception(exc_val)
         # 退出 context manager
         self._span.__exit__(exc_type, exc_val, exc_tb)
-        _state.current_span = None
 
     def set_attribute(self, key: str, value: Any) -> None:
         """
@@ -99,8 +96,9 @@ class SpanContext:
             value: 属性值
 
         """
-        if _state.current_span is not None:
-            _state.current_span.set_attribute(key, str(value))
+        current = trace.get_current_span()
+        if current.is_recording():
+            current.set_attribute(key, str(value))
 
     def set_status(self, status: str) -> None:
         """
@@ -212,20 +210,13 @@ def get_trace_id() -> str:
         str: UUID 格式的 trace_id，如果无效则返回空字符串
 
     """
-    # 优先使用存储的当前 span
-    if _state.current_span is not None:
-        span_context = _state.current_span.get_span_context()
-        if span_context.is_valid:
-            return str(uuid.UUID(int=span_context.trace_id))
-
-    # 回退到全局获取（用于 production/development 模式）
     if _state.tracer is None:
         return ""
 
-    current_span = trace.get_current_span()
-    span_context = current_span.get_span_context()
-    if span_context.is_valid:
-        return str(uuid.UUID(int=span_context.trace_id))
+    current = trace.get_current_span()
+    ctx = current.get_span_context()
+    if ctx.is_valid:
+        return str(uuid.UUID(int=ctx.trace_id))
     return ""
 
 
@@ -238,20 +229,13 @@ def get_span_id() -> str:
         str: 16位十六进制 span_id，如果无效则返回空字符串
 
     """
-    # 优先使用存储的当前 span
-    if _state.current_span is not None:
-        span_context = _state.current_span.get_span_context()
-        if span_context.is_valid:
-            return format(span_context.span_id, "016x")
-
-    # 回退到全局获取（用于 production/development 模式）
     if _state.tracer is None:
         return ""
 
-    current_span = trace.get_current_span()
-    span_context = current_span.get_span_context()
-    if span_context.is_valid:
-        return format(span_context.span_id, "016x")
+    current = trace.get_current_span()
+    ctx = current.get_span_context()
+    if ctx.is_valid:
+        return format(ctx.span_id, "016x")
     return ""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ unfixable = []
     "PLW0603",
     "PLR0913",
     "PLC0415",
+    "RUF002",  # 中文文档中的全角标点符号（中文项目正常使用）
 ]
 
 # __init__.py 可以没有 docstring


### PR DESCRIPTION
## 概述

简化 `packages/foundation/src/ditto_foundation/observability/tracing.py` 的代码实现，提升可维护性和可读性。

**相关计划**: [docs/plans/2026-01-11-foundation-simplification.md](https://github.com/cosmos-arc/ditto/blob/main/docs/plans/2026-01-11-foundation-simplification.md) 阶段2

---

## 变更内容

### 任务 2.1: 全局状态管理简化

- 引入 `TracingState` dataclass 封装所有 tracing 全局状态
- 将 3 个分散的全局变量 (`_tracer`, `_in_memory_exporter`, `_current_span`) 封装到单一 `_state` 对象中
- 简化 `reset_tracing()` 逻辑 (8行 → 2行)
- 添加 `_get_in_memory_exporter()` 辅助函数用于测试

### 任务 2.2: SpanContext 简化

- 从 `TracingState` 中移除 `current_span` 字段
- 移除手动管理 `_current_span` 全局变量的逻辑
- 完全依赖 OpenTelemetry 的内置 `trace.get_current_span()` 机制
- 简化 `SpanContext.__enter__` / `__exit__` / `set_attribute` 方法
- 移除不必要的 `@overload` 装饰器

### 代码质量改进

- 修复 SLF001: testing.py 不再直接访问私有成员
- 修复 RUF002: 在 pyproject.toml 中配置忽略中文全角标点
- 更新 observability/README.md 添加内部实现说明

---

## 指标改进

| 指标 | 修改前 | 修改后 | 改进 |
|------|--------|--------|------|
| **tracing.py 覆盖率** | 56.49% | **81.15%** | +24.66% |
| **代码行数** | 262 行 | 245 行 | -17 行 (-6.5%) |
| **全局变量数量** | 3 个 | 1 个 | -67% |
| **单元测试** | 20/20 ✅ | 20/20 ✅ | 通过 |

---

## 测试计划

- [x] 单元测试: `pixi run -e dev pytest packages/foundation/tests/unit/test_observability_unit.py`
- [x] 代码检查: `pixi run -e dev ruff check`
- [x] 类型检查: `pixi run -e dev mypy`
- [x] 安全检查: `pixi run -e dev bandit`
- [x] Pre-commit: `pixi run -e dev pre-commit-run`

---

## 破坏性变更

**无** - 所有使用方都在本项目内，已同步更新。

---

## 审查重点

1. **TracingState dataclass 设计** - 是否正确封装了全局状态
2. **trace.get_current_span() 使用** - 是否正确替代了手动 span 管理
3. **测试辅助函数** - `_get_in_memory_exporter()` / `_get_in_memory_reader()` 是否合理