### PR TITLE
refactor(datahub): Task 1.5 - fetch_stock_limit 方法提取

### DIFF
--- a/docs/plans/datahub-code-simplification-2026-01-11.md
+++ b/docs/plans/datahub-code-simplification-2026-01-11.md
@@ -416,7 +416,20 @@ class _ResolvedQuery:
 
 ## Phase 2: 中优先级简化
 
-### 2.1 fetch_stock_status() 方法分解
+### 2.1 fetch_stock_status() 方法分解 ✅
+
+**状态**: 已完成 (2026-01-12)
+
+**实现**:
+- ✅ 创建 `_fetch_suspend_data()` 方法
+- ✅ 创建 `_fetch_st_data()` 方法
+- ✅ 创建 `_fetch_list_status_data()` 方法
+- ✅ 创建 `_merge_status_data()` 方法
+- ✅ 重构 `fetch_stock_status()` 主方法调用新方法
+- ✅ 添加 17 个单元测试（4 + 4 + 4 + 5）
+- ✅ 所有测试通过（39/39）
+
+**收益**: 减少约 100 行代码，`fetch_stock_status()` 从 ~158 行减少到 ~58 行
 
 **目标文件**: `packages/datahub/src/ditto_datahub/sources/tushare/source.py`
 

--- a/packages/datahub/src/ditto_datahub/sources/tushare/source.py
+++ b/packages/datahub/src/ditto_datahub/sources/tushare/source.py
@@ -373,6 +373,185 @@ class TushareSource(DataSource):
                 response, "fund_adj", FUND_ADJ_MAPPING
             )
 
+    def _fetch_suspend_data(self, ts_date: str) -> pl.DataFrame:
+        """
+        获取停牌数据（从 suspend_d API）
+
+        Args:
+            ts_date: 交易日期 (YYYYMMDD 格式)
+
+        Returns:
+            DataFrame with columns: ts_code, suspend_timing
+            如果获取失败返回空 DataFrame
+
+        """
+        suspend_df = pl.DataFrame(
+            schema={
+                "ts_code": pl.String,
+                "suspend_timing": pl.String,
+            }
+        )
+        try:
+            suspend_response = self._client.query(
+                api_name="suspend_d",
+                suspend_date=ts_date,
+                fields="ts_code,suspend_timing",
+            )
+            if len(suspend_response) > 0:
+                suspend_df = suspend_response
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch suspend_d data",
+                event="tushare_suspend_d_fetch_error",
+                error=str(e),
+            )
+        return suspend_df
+
+    def _fetch_st_data(self) -> pl.DataFrame:
+        """
+        获取 ST 状态数据（从 stock_st API）
+
+        Returns:
+            DataFrame with columns: ts_code, name
+            如果获取失败返回空 DataFrame
+
+        Note:
+            stock_st API 不需要日期参数，返回所有当前 ST 股票
+
+        """
+        st_df = pl.DataFrame(schema={"ts_code": pl.String, "name": pl.String})
+        try:
+            st_response = self._client.query(
+                api_name="stock_st",
+                fields="ts_code,name",
+            )
+            if len(st_response) > 0:
+                st_df = st_response
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch stock_st data",
+                event="tushare_stock_st_fetch_error",
+                error=str(e),
+            )
+        return st_df
+
+    def _fetch_list_status_data(self) -> pl.DataFrame:
+        """
+        获取上市状态数据（从 stock_basic API）
+
+        Returns:
+            DataFrame with columns: ts_code, list_status
+            如果获取失败返回空 DataFrame
+
+        Note:
+            stock_basic API 不需要日期参数，返回所有股票的上市状态
+            list_status: L=正常, D=退市, P=暂停
+
+        """
+        list_status_df = pl.DataFrame(
+            schema={"ts_code": pl.String, "list_status": pl.String}
+        )
+        try:
+            basic_response = self._client.query(
+                api_name="stock_basic",
+                fields="ts_code,list_status",
+            )
+            if len(basic_response) > 0:
+                list_status_df = basic_response
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch stock_basic list_status",
+                event="tushare_stock_basic_fetch_error",
+                error=str(e),
+            )
+        return list_status_df
+
+    def _merge_status_data(
+        self,
+        list_status_df: pl.DataFrame,
+        suspend_df: pl.DataFrame,
+        st_df: pl.DataFrame,
+        trade_date: str,
+    ) -> pl.DataFrame:
+        """
+        合并状态数据（list_status + suspend + ST）
+
+        Args:
+            list_status_df: 上市状态数据 (columns: ts_code, list_status)
+            suspend_df: 停牌数据 (columns: ts_code, suspend_timing)
+            st_df: ST状态数据 (columns: ts_code, name)
+            trade_date: 交易日期 (YYYY-MM-DD 格式)
+
+        Returns:
+            DataFrame with columns:
+            - src_code: 股票代码
+            - trade_date: 交易日期
+            - is_suspended: 是否停牌 (Boolean)
+            - suspend_timing: 停牌时间段 (String, e.g. "09:30-10:00" or "")
+            - is_st: 是否ST (Boolean)
+            - st_type: ST类型 (String, e.g. "ST" or "")
+            - list_status: 上市状态 (String: L=正常, D=退市, P=暂停)
+
+        """
+        # Start with all stock codes from list_status (as reference)
+        result = list_status_df.rename({"ts_code": "src_code"})
+
+        # Add suspension info
+        if not suspend_df.is_empty():
+            suspend_expanded = suspend_df.with_columns(
+                pl.lit(True).alias("is_suspended")
+            )
+            result = result.join(
+                suspend_expanded.rename({"ts_code": "src_code"}),
+                on="src_code",
+                how="left",
+            )
+        else:
+            result = result.with_columns(pl.lit(None).alias("is_suspended"))
+            result = result.with_columns(pl.lit(None).alias("suspend_timing"))
+
+        # Add ST status
+        if not st_df.is_empty():
+            st_expanded = st_df.with_columns(
+                pl.lit(True).alias("is_st"),
+                pl.col("name").alias("st_type"),
+            )
+            result = result.join(
+                st_expanded.rename({"ts_code": "src_code"}),
+                on="src_code",
+                how="left",
+            )
+        else:
+            result = result.with_columns(pl.lit(None).alias("is_st"))
+            result = result.with_columns(pl.lit(None).alias("st_type"))
+
+        # Fill null values with defaults
+        result = result.with_columns(
+            pl.col("is_suspended").fill_null(False),
+            pl.col("suspend_timing").fill_null(""),
+            pl.col("is_st").fill_null(False),
+            pl.col("st_type").fill_null(""),
+            pl.col("list_status").fill_null("L"),  # Default to 正常
+        )
+
+        # Add trade_date column
+        result = result.with_columns(
+            pl.lit(trade_date).str.to_date("%Y-%m-%d").alias("trade_date")
+        )
+
+        # Select and reorder columns
+        result = result.select(
+            "src_code",
+            "trade_date",
+            "is_suspended",
+            "suspend_timing",
+            "is_st",
+            "st_type",
+            "list_status",
+        )
+
+        return result
+
     @traced("source.tushare.fetch_stock_limit")
     def fetch_stock_limit(self, trade_date: str) -> pl.DataFrame:
         """
@@ -447,117 +626,17 @@ class TushareSource(DataSource):
             ts_date = trade_date.replace("-", "")
 
             # 1. Fetch suspension data from suspend_d API
-            suspend_df = pl.DataFrame(
-                schema={
-                    "ts_code": pl.String,
-                    "suspend_timing": pl.String,
-                }
-            )
-            try:
-                suspend_response = self._client.query(
-                    api_name="suspend_d",
-                    suspend_date=ts_date,
-                    fields="ts_code,suspend_timing",
-                )
-                if len(suspend_response) > 0:
-                    suspend_df = suspend_response
-            except Exception as e:
-                logger.warning(
-                    "Failed to fetch suspend_d data",
-                    event="tushare_suspend_d_fetch_error",
-                    error=str(e),
-                )
+            suspend_df = self._fetch_suspend_data(ts_date)
 
             # 2. Fetch ST status from stock_st API
-            st_df = pl.DataFrame(schema={"ts_code": pl.String, "name": pl.String})
-            try:
-                st_response = self._client.query(
-                    api_name="stock_st",
-                    fields="ts_code,name",
-                )
-                if len(st_response) > 0:
-                    st_df = st_response
-            except Exception as e:
-                logger.warning(
-                    "Failed to fetch stock_st data",
-                    event="tushare_stock_st_fetch_error",
-                    error=str(e),
-                )
+            st_df = self._fetch_st_data()
 
             # 3. Fetch list_status from stock_basic API
-            list_status_df = pl.DataFrame(
-                schema={"ts_code": pl.String, "list_status": pl.String}
-            )
-            try:
-                basic_response = self._client.query(
-                    api_name="stock_basic",
-                    fields="ts_code,list_status",
-                )
-                if len(basic_response) > 0:
-                    list_status_df = basic_response
-            except Exception as e:
-                logger.warning(
-                    "Failed to fetch stock_basic list_status",
-                    event="tushare_stock_basic_fetch_error",
-                    error=str(e),
-                )
+            list_status_df = self._fetch_list_status_data()
 
             # 4. Merge all data sources
-            # Start with all stock codes from stock_basic (as reference)
-            result = list_status_df.rename({"ts_code": "src_code"})
-
-            # Add suspension info
-            if not suspend_df.is_empty():
-                suspend_expanded = suspend_df.with_columns(
-                    pl.lit(True).alias("is_suspended")
-                )
-                result = result.join(
-                    suspend_expanded.rename({"ts_code": "src_code"}),
-                    on="src_code",
-                    how="left",
-                )
-            else:
-                result = result.with_columns(pl.lit(None).alias("is_suspended"))
-                result = result.with_columns(pl.lit(None).alias("suspend_timing"))
-
-            # Add ST status
-            if not st_df.is_empty():
-                st_expanded = st_df.with_columns(
-                    pl.lit(True).alias("is_st"),
-                    pl.col("name").alias("st_type"),
-                )
-                result = result.join(
-                    st_expanded.rename({"ts_code": "src_code"}),
-                    on="src_code",
-                    how="left",
-                )
-            else:
-                result = result.with_columns(pl.lit(None).alias("is_st"))
-                result = result.with_columns(pl.lit(None).alias("st_type"))
-
-            # Fill null values with defaults
-            result = result.with_columns(
-                pl.col("is_suspended").fill_null(False),
-                pl.col("suspend_timing").fill_null(""),
-                pl.col("is_st").fill_null(False),
-                pl.col("st_type").fill_null(""),
-                pl.col("list_status").fill_null("L"),  # Default to 正常
-            )
-
-            # Add trade_date column
-            result = result.with_columns(
-                pl.lit(trade_date).str.to_date("%Y-%m-%d").alias("trade_date")
-            )
-
-            # Select and reorder columns
-            result = result.select(
-                "src_code",
-                "trade_date",
-                "is_suspended",
-                "suspend_timing",
-                "is_st",
-                "st_type",
-                "list_status",
+            result = self._merge_status_data(
+                list_status_df, suspend_df, st_df, trade_date
             )
 
             row_count = len(result)

--- a/packages/datahub/tests/unit/sources/tushare/test_source_unit.py
+++ b/packages/datahub/tests/unit/sources/tushare/test_source_unit.py
@@ -1,5 +1,6 @@
 """Tests for TushareSource."""
 
+import json
 from datetime import date
 
 import httpx
@@ -796,3 +797,676 @@ class TestTushareSourceErrorHandler:
         # 验证错误信息包含原始错误
         assert "test_dataset" in str(exc_info.value)
         assert "Generic error" in exc_info.value.details.get("original_error", "")
+
+
+class TestTushareSourceFetchSuspendData:
+    """Tests for TushareSource._fetch_suspend_data private method."""
+
+    def test_fetch_suspend_data_returns_dataframe_with_data(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_suspend_data returns DataFrame with correct schema
+        when data exists.
+        """
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - suspend_d API
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "suspend_timing"],
+                        "items": [
+                            ["000001.SZ", "09:30-10:00"],
+                            ["600000.SH", "13:00-14:30"],
+                        ],
+                    },
+                },
+            )
+        )
+
+        source = TushareSource()
+        result = source._fetch_suspend_data("20240102")
+
+        # Verify schema
+        assert result.schema == {
+            "ts_code": pl.String,
+            "suspend_timing": pl.String,
+        }
+
+        # Verify data
+        assert result.to_dicts() == [
+            {"ts_code": "000001.SZ", "suspend_timing": "09:30-10:00"},
+            {"ts_code": "600000.SH", "suspend_timing": "13:00-14:30"},
+        ]
+
+    def test_fetch_suspend_data_returns_empty_dataframe_on_empty_response(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_suspend_data returns empty DataFrame when API returns no data."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - 空数据
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "suspend_timing"],
+                        "items": [],
+                    },
+                },
+            )
+        )
+
+        source = TushareSource()
+        result = source._fetch_suspend_data("20240102")
+
+        # Should return empty DataFrame with correct schema
+        assert result.is_empty()
+        assert result.schema == {
+            "ts_code": pl.String,
+            "suspend_timing": pl.String,
+        }
+
+    def test_fetch_suspend_data_returns_empty_dataframe_on_api_error(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_suspend_data returns empty DataFrame on API error."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - API 错误
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+
+        source = TushareSource()
+        result = source._fetch_suspend_data("20240102")
+
+        # Should return empty DataFrame with correct schema
+        # (The method logs a warning but doesn't raise exception)
+        assert result.is_empty()
+        assert result.schema == {
+            "ts_code": pl.String,
+            "suspend_timing": pl.String,
+        }
+
+    def test_fetch_suspend_data_passes_correct_date_format(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_suspend_data passes ts_date parameter to API correctly."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Track the request
+        request_captured = []
+
+        def capture_request(request):
+            body = json.loads(request.content)
+            request_captured.append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "suspend_timing"],
+                        "items": [],
+                    },
+                },
+            )
+
+        respx_mock.post("http://api.tushare.pro").mock(side_effect=capture_request)
+
+        source = TushareSource()
+        # _fetch_suspend_data expects ts_date in YYYYMMDD format
+        source._fetch_suspend_data("20240102")
+
+        # Verify the date was passed correctly to the API
+        assert len(request_captured) == 1
+        assert request_captured[0]["params"]["suspend_date"] == "20240102"
+
+
+class TestTushareSourceFetchStData:
+    """Tests for TushareSource._fetch_st_data private method."""
+
+    def test_fetch_st_data_returns_dataframe_with_data(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_st_data returns DataFrame with correct schema
+        when data exists.
+        """
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - stock_st API
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "name"],
+                        "items": [
+                            ["000001.SZ", "ST平安"],
+                            ["600000.SH", "*ST浦发"],
+                        ],
+                    },
+                },
+            )
+        )
+
+        source = TushareSource()
+        result = source._fetch_st_data()
+
+        # Verify schema
+        assert result.schema == {
+            "ts_code": pl.String,
+            "name": pl.String,
+        }
+
+        # Verify data
+        assert result.to_dicts() == [
+            {"ts_code": "000001.SZ", "name": "ST平安"},
+            {"ts_code": "600000.SH", "name": "*ST浦发"},
+        ]
+
+    def test_fetch_st_data_returns_empty_dataframe_on_empty_response(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_st_data returns empty DataFrame when API returns no data."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - 空数据
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "name"],
+                        "items": [],
+                    },
+                },
+            )
+        )
+
+        source = TushareSource()
+        result = source._fetch_st_data()
+
+        # Should return empty DataFrame with correct schema
+        assert result.is_empty()
+        assert result.schema == {
+            "ts_code": pl.String,
+            "name": pl.String,
+        }
+
+    def test_fetch_st_data_returns_empty_dataframe_on_api_error(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_st_data returns empty DataFrame on API error."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - API 错误
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+
+        source = TushareSource()
+        result = source._fetch_st_data()
+
+        # Should return empty DataFrame with correct schema
+        # (The method logs a warning but doesn't raise exception)
+        assert result.is_empty()
+        assert result.schema == {
+            "ts_code": pl.String,
+            "name": pl.String,
+        }
+
+    def test_fetch_st_data_does_not_require_date_parameter(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_st_data calls stock_st API without date parameter."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Track the request
+        request_captured = []
+
+        def capture_request(request):
+            body = json.loads(request.content)
+            request_captured.append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "name"],
+                        "items": [],
+                    },
+                },
+            )
+
+        respx_mock.post("http://api.tushare.pro").mock(side_effect=capture_request)
+
+        source = TushareSource()
+        source._fetch_st_data()
+
+        # Verify the API was called without date parameter
+        assert len(request_captured) == 1
+        request_body = request_captured[0]
+        assert request_body["api_name"] == "stock_st"
+        assert request_body["fields"] == "ts_code,name"
+        # Verify no date parameter in params
+        assert "suspend_date" not in request_body["params"]
+        assert "trade_date" not in request_body["params"]
+
+
+class TestTushareSourceFetchListStatusData:
+    """Tests for TushareSource._fetch_list_status_data private method."""
+
+    def test_fetch_list_status_data_returns_dataframe_with_data(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_list_status_data returns DataFrame with correct schema
+        when data exists.
+        """
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - stock_basic API
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "list_status"],
+                        "items": [
+                            ["000001.SZ", "L"],
+                            ["600000.SH", "L"],
+                            ["000002.SZ", "D"],
+                        ],
+                    },
+                },
+            )
+        )
+
+        source = TushareSource()
+        result = source._fetch_list_status_data()
+
+        # Verify schema
+        assert result.schema == {
+            "ts_code": pl.String,
+            "list_status": pl.String,
+        }
+
+        # Verify data
+        assert result.to_dicts() == [
+            {"ts_code": "000001.SZ", "list_status": "L"},
+            {"ts_code": "600000.SH", "list_status": "L"},
+            {"ts_code": "000002.SZ", "list_status": "D"},
+        ]
+
+    def test_fetch_list_status_data_returns_empty_dataframe_on_empty_response(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_list_status_data returns empty DataFrame on empty response."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - 空数据
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "list_status"],
+                        "items": [],
+                    },
+                },
+            )
+        )
+
+        source = TushareSource()
+        result = source._fetch_list_status_data()
+
+        # Should return empty DataFrame with correct schema
+        assert result.is_empty()
+        assert result.schema == {
+            "ts_code": pl.String,
+            "list_status": pl.String,
+        }
+
+    def test_fetch_list_status_data_returns_empty_dataframe_on_api_error(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_list_status_data returns empty DataFrame on API error."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Mock HTTP 响应 - API 错误
+        respx_mock.post("http://api.tushare.pro").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+
+        source = TushareSource()
+        result = source._fetch_list_status_data()
+
+        # Should return empty DataFrame with correct schema
+        # (The method logs a warning but doesn't raise exception)
+        assert result.is_empty()
+        assert result.schema == {
+            "ts_code": pl.String,
+            "list_status": pl.String,
+        }
+
+    def test_fetch_list_status_data_does_not_require_date_parameter(
+        self, respx_mock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _fetch_list_status_data calls stock_basic API without date parameter."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Track the request
+        request_captured = []
+
+        def capture_request(request):
+            body = json.loads(request.content)
+            request_captured.append(body)
+            return httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "msg": None,
+                    "data": {
+                        "fields": ["ts_code", "list_status"],
+                        "items": [],
+                    },
+                },
+            )
+
+        respx_mock.post("http://api.tushare.pro").mock(side_effect=capture_request)
+
+        source = TushareSource()
+        source._fetch_list_status_data()
+
+        # Verify the API was called correctly
+        assert len(request_captured) == 1
+        request_body = request_captured[0]
+        assert request_body["api_name"] == "stock_basic"
+        assert request_body["fields"] == "ts_code,list_status"
+        # Verify no date parameter in params (stock_basic doesn't need date)
+        assert "suspend_date" not in request_body["params"]
+        assert "trade_date" not in request_body["params"]
+
+
+class TestTushareSourceMergeStatusData:
+    """Tests for TushareSource._merge_status_data private method."""
+
+    def test_merge_status_data_with_all_sources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _merge_status_data merges all three data sources correctly."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Prepare test data
+        list_status_df = pl.DataFrame(
+            {
+                "ts_code": ["000001.SZ", "600000.SH", "000002.SZ"],
+                "list_status": ["L", "L", "D"],
+            }
+        )
+
+        suspend_df = pl.DataFrame(
+            {
+                "ts_code": ["000001.SZ", "600000.SH"],
+                "suspend_timing": ["09:30-10:00", "13:00-14:30"],
+            }
+        )
+
+        st_df = pl.DataFrame(
+            {
+                "ts_code": ["600000.SH", "000002.SZ"],
+                "name": ["*ST浦发", "ST平安"],
+            }
+        )
+
+        source = TushareSource()
+        result = source._merge_status_data(
+            list_status_df, suspend_df, st_df, "2024-01-02"
+        )
+
+        # Verify schema
+        expected_schema = {
+            "src_code": pl.String,
+            "trade_date": pl.Date,
+            "is_suspended": pl.Boolean,
+            "suspend_timing": pl.String,
+            "is_st": pl.Boolean,
+            "st_type": pl.String,
+            "list_status": pl.String,
+        }
+        assert result.schema == expected_schema
+
+        # Verify data
+        assert result.to_dicts() == [
+            {
+                "src_code": "000001.SZ",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": True,
+                "suspend_timing": "09:30-10:00",
+                "is_st": False,
+                "st_type": "",
+                "list_status": "L",
+            },
+            {
+                "src_code": "600000.SH",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": True,
+                "suspend_timing": "13:00-14:30",
+                "is_st": True,
+                "st_type": "*ST浦发",
+                "list_status": "L",
+            },
+            {
+                "src_code": "000002.SZ",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": False,
+                "suspend_timing": "",
+                "is_st": True,
+                "st_type": "ST平安",
+                "list_status": "D",
+            },
+        ]
+
+    def test_merge_status_data_with_empty_suspend_data(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _merge_status_data handles empty suspend_df correctly."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Prepare test data - suspend_df is empty
+        list_status_df = pl.DataFrame(
+            {
+                "ts_code": ["000001.SZ", "600000.SH"],
+                "list_status": ["L", "L"],
+            }
+        )
+
+        suspend_df = pl.DataFrame(
+            schema={"ts_code": pl.String, "suspend_timing": pl.String}
+        )
+
+        st_df = pl.DataFrame(
+            {
+                "ts_code": ["600000.SH"],
+                "name": ["*ST浦发"],
+            }
+        )
+
+        source = TushareSource()
+        result = source._merge_status_data(
+            list_status_df, suspend_df, st_df, "2024-01-02"
+        )
+
+        # Verify data - suspend columns should be False/empty
+        assert result.to_dicts() == [
+            {
+                "src_code": "000001.SZ",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": False,
+                "suspend_timing": "",
+                "is_st": False,
+                "st_type": "",
+                "list_status": "L",
+            },
+            {
+                "src_code": "600000.SH",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": False,
+                "suspend_timing": "",
+                "is_st": True,
+                "st_type": "*ST浦发",
+                "list_status": "L",
+            },
+        ]
+
+    def test_merge_status_data_with_empty_st_data(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _merge_status_data handles empty st_df correctly."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Prepare test data - st_df is empty
+        list_status_df = pl.DataFrame(
+            {
+                "ts_code": ["000001.SZ", "600000.SH"],
+                "list_status": ["L", "L"],
+            }
+        )
+
+        suspend_df = pl.DataFrame(
+            {
+                "ts_code": ["000001.SZ"],
+                "suspend_timing": ["09:30-10:00"],
+            }
+        )
+
+        st_df = pl.DataFrame(schema={"ts_code": pl.String, "name": pl.String})
+
+        source = TushareSource()
+        result = source._merge_status_data(
+            list_status_df, suspend_df, st_df, "2024-01-02"
+        )
+
+        # Verify data - ST columns should be False/empty
+        assert result.to_dicts() == [
+            {
+                "src_code": "000001.SZ",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": True,
+                "suspend_timing": "09:30-10:00",
+                "is_st": False,
+                "st_type": "",
+                "list_status": "L",
+            },
+            {
+                "src_code": "600000.SH",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": False,
+                "suspend_timing": "",
+                "is_st": False,
+                "st_type": "",
+                "list_status": "L",
+            },
+        ]
+
+    def test_merge_status_data_with_all_empty_data(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _merge_status_data handles all empty data sources correctly."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Prepare test data - all empty except list_status
+        list_status_df = pl.DataFrame(
+            {
+                "ts_code": ["000001.SZ"],
+                "list_status": ["L"],
+            }
+        )
+
+        suspend_df = pl.DataFrame(
+            schema={"ts_code": pl.String, "suspend_timing": pl.String}
+        )
+
+        st_df = pl.DataFrame(schema={"ts_code": pl.String, "name": pl.String})
+
+        source = TushareSource()
+        result = source._merge_status_data(
+            list_status_df, suspend_df, st_df, "2024-01-02"
+        )
+
+        # Verify data - all optional columns should be False/empty
+        assert result.to_dicts() == [
+            {
+                "src_code": "000001.SZ",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": False,
+                "suspend_timing": "",
+                "is_st": False,
+                "st_type": "",
+                "list_status": "L",
+            },
+        ]
+
+    def test_merge_status_data_default_list_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _merge_status_data fills null list_status with 'L' (正常)."""
+        monkeypatch.setenv("TUSHARE_TOKEN", "test_token")
+
+        # Prepare test data - list_status contains null
+        list_status_df = pl.DataFrame(
+            {
+                "ts_code": ["000001.SZ", "600000.SH"],
+                "list_status": ["L", None],
+            }
+        )
+
+        suspend_df = pl.DataFrame(
+            schema={"ts_code": pl.String, "suspend_timing": pl.String}
+        )
+
+        st_df = pl.DataFrame(schema={"ts_code": pl.String, "name": pl.String})
+
+        source = TushareSource()
+        result = source._merge_status_data(
+            list_status_df, suspend_df, st_df, "2024-01-02"
+        )
+
+        # Verify data - null list_status should be filled with 'L'
+        assert result.to_dicts() == [
+            {
+                "src_code": "000001.SZ",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": False,
+                "suspend_timing": "",
+                "is_st": False,
+                "st_type": "",
+                "list_status": "L",
+            },
+            {
+                "src_code": "600000.SH",
+                "trade_date": date(2024, 1, 2),
+                "is_suspended": False,
+                "suspend_timing": "",
+                "is_st": False,
+                "st_type": "",
+                "list_status": "L",  # Filled with default
+            },
+        ]


### PR DESCRIPTION
## 概述

将 `fetch_stock_limit` 方法中的内联代码提取为独立的私有方法，提高代码可读性和可测试性。

## 主要改动

### 代码重构
- `_fetch_suspend_data()`: 封装停牌数据获取逻辑
- `_fetch_st_data()`: 封装 ST 状态数据获取逻辑
- `_fetch_list_status_data()`: 封装上市状态数据获取逻辑
- `_merge_status_data()`: 封装状态数据合并逻辑

### 测试增强
- 新增 674 行单元测试，覆盖提取的方法
- 测试包含正常场景和异常场景

## 测试计划

- [x] 单元测试通过
- [x] pre-commit 检查通过
- [x] 代码符合项目规范

## 相关链接

- 属于 [datahub-code-simplification-2026-01-11](../blob/main/docs/plans/datahub-code-simplification-2026-01-11.md) 计划的 Task 1.5