### PR TITLE
refactor(datahub): Phase 3.3 - 提取 Tushare Schema 常量

### DIFF
--- a/packages/datahub/src/ditto_datahub/meta/__init__.py
+++ b/packages/datahub/src/ditto_datahub/meta/__init__.py
@@ -12,6 +12,8 @@ from ditto_datahub.meta.schemas import (
     INDEX_WEIGHT_SCHEMA,
     STOCK_DAILY_SCHEMA,
     STOCK_STATUS_SCHEMA,  # B.3: Stock status schema
+    TUSHARE_LIST_STATUS_SCHEMA,  # Tushare source schemas
+    TUSHARE_ST_SCHEMA,  # Tushare source schemas
     UNIVERSE_CONSTITUENT_SCHEMA,
 )
 
@@ -22,5 +24,7 @@ __all__ = [
     "INDEX_WEIGHT_SCHEMA",
     "STOCK_DAILY_SCHEMA",
     "STOCK_STATUS_SCHEMA",
+    "TUSHARE_LIST_STATUS_SCHEMA",
+    "TUSHARE_ST_SCHEMA",
     "UNIVERSE_CONSTITUENT_SCHEMA",
 ]

--- a/packages/datahub/src/ditto_datahub/meta/__init__.py
+++ b/packages/datahub/src/ditto_datahub/meta/__init__.py
@@ -14,6 +14,7 @@ from ditto_datahub.meta.schemas import (
     STOCK_STATUS_SCHEMA,  # B.3: Stock status schema
     TUSHARE_LIST_STATUS_SCHEMA,  # Tushare source schemas
     TUSHARE_ST_SCHEMA,  # Tushare source schemas
+    TUSHARE_SUSPEND_SCHEMA,  # Tushare source schemas
     UNIVERSE_CONSTITUENT_SCHEMA,
 )
 
@@ -26,5 +27,6 @@ __all__ = [
     "STOCK_STATUS_SCHEMA",
     "TUSHARE_LIST_STATUS_SCHEMA",
     "TUSHARE_ST_SCHEMA",
+    "TUSHARE_SUSPEND_SCHEMA",
     "UNIVERSE_CONSTITUENT_SCHEMA",
 ]

--- a/packages/datahub/src/ditto_datahub/meta/schemas.py
+++ b/packages/datahub/src/ditto_datahub/meta/schemas.py
@@ -138,3 +138,26 @@ STOCK_STATUS_SCHEMA: dict[str, type[pl.DataType]] = {
     "source": pl.Utf8,
     "src_code": pl.Utf8,
 }
+
+
+# ============================================================
+# Tushare Source Schemas (for empty DataFrame creation)
+# ============================================================
+# These schemas are used in Tushare source methods to create empty DataFrames
+# when API calls fail. They define the minimal structure for temporary DataFrames.
+
+
+# ST (Special Treatment) stock schema
+# Used in TushareSource._fetch_st_data() for stock_st API
+TUSHARE_ST_SCHEMA: dict[str, type[pl.DataType]] = {
+    "ts_code": pl.String,
+    "name": pl.String,
+}
+
+
+# List status schema
+# Used in TushareSource._fetch_list_status_data() for stock_basic API
+TUSHARE_LIST_STATUS_SCHEMA: dict[str, type[pl.DataType]] = {
+    "ts_code": pl.String,
+    "list_status": pl.String,
+}

--- a/packages/datahub/src/ditto_datahub/meta/schemas.py
+++ b/packages/datahub/src/ditto_datahub/meta/schemas.py
@@ -155,6 +155,14 @@ TUSHARE_ST_SCHEMA: dict[str, type[pl.DataType]] = {
 }
 
 
+# Suspend (停牌) schema
+# Used in TushareSource._fetch_suspend_data() for suspend_d API
+TUSHARE_SUSPEND_SCHEMA: dict[str, type[pl.DataType]] = {
+    "ts_code": pl.String,
+    "suspend_timing": pl.String,
+}
+
+
 # List status schema
 # Used in TushareSource._fetch_list_status_data() for stock_basic API
 TUSHARE_LIST_STATUS_SCHEMA: dict[str, type[pl.DataType]] = {

--- a/packages/datahub/src/ditto_datahub/sources/tushare/source.py
+++ b/packages/datahub/src/ditto_datahub/sources/tushare/source.py
@@ -8,6 +8,10 @@ from contextlib import contextmanager
 import polars as pl
 from ditto_foundation import M, logger, traced
 
+from ditto_datahub.meta.schemas import (
+    TUSHARE_LIST_STATUS_SCHEMA,
+    TUSHARE_ST_SCHEMA,
+)
 from ditto_datahub.sources.base import (
     DataSource,
     SourceAuthenticationError,
@@ -419,7 +423,7 @@ class TushareSource(DataSource):
             stock_st API 不需要日期参数，返回所有当前 ST 股票
 
         """
-        st_df = pl.DataFrame(schema={"ts_code": pl.String, "name": pl.String})
+        st_df = pl.DataFrame(schema=TUSHARE_ST_SCHEMA)
         try:
             st_response = self._client.query(
                 api_name="stock_st",
@@ -448,9 +452,7 @@ class TushareSource(DataSource):
             list_status: L=正常, D=退市, P=暂停
 
         """
-        list_status_df = pl.DataFrame(
-            schema={"ts_code": pl.String, "list_status": pl.String}
-        )
+        list_status_df = pl.DataFrame(schema=TUSHARE_LIST_STATUS_SCHEMA)
         try:
             basic_response = self._client.query(
                 api_name="stock_basic",

--- a/packages/datahub/src/ditto_datahub/sources/tushare/source.py
+++ b/packages/datahub/src/ditto_datahub/sources/tushare/source.py
@@ -11,6 +11,7 @@ from ditto_foundation import M, logger, traced
 from ditto_datahub.meta.schemas import (
     TUSHARE_LIST_STATUS_SCHEMA,
     TUSHARE_ST_SCHEMA,
+    TUSHARE_SUSPEND_SCHEMA,
 )
 from ditto_datahub.sources.base import (
     DataSource,
@@ -389,12 +390,7 @@ class TushareSource(DataSource):
             如果获取失败返回空 DataFrame
 
         """
-        suspend_df = pl.DataFrame(
-            schema={
-                "ts_code": pl.String,
-                "suspend_timing": pl.String,
-            }
-        )
+        suspend_df = pl.DataFrame(schema=TUSHARE_SUSPEND_SCHEMA)
         try:
             suspend_response = self._client.query(
                 api_name="suspend_d",

--- a/packages/datahub/tests/unit/meta/test_schemas_unit.py
+++ b/packages/datahub/tests/unit/meta/test_schemas_unit.py
@@ -10,6 +10,7 @@ from ditto_datahub.meta.schemas import (
     STOCK_STATUS_SCHEMA,  # B.3: Stock status schema
     TUSHARE_LIST_STATUS_SCHEMA,  # Tushare source schemas
     TUSHARE_ST_SCHEMA,  # Tushare source schemas
+    TUSHARE_SUSPEND_SCHEMA,  # Tushare source schemas
     UNIVERSE_CONSTITUENT_SCHEMA,
 )
 
@@ -349,3 +350,29 @@ class TestTushareListStatusSchema:
     def test_list_status_is_string(self) -> None:
         """list_status field should be String."""
         assert TUSHARE_LIST_STATUS_SCHEMA["list_status"] == pl.String
+
+
+class TestTushareSuspendSchema:
+    """Tests for TUSHARE_SUSPEND_SCHEMA."""
+
+    def test_schema_is_dict(self) -> None:
+        """Schema should be a dictionary."""
+        assert isinstance(TUSHARE_SUSPEND_SCHEMA, dict)
+
+    def test_schema_has_all_required_fields(self) -> None:
+        """Schema should have ts_code and suspend_timing fields."""
+        required_fields = {"ts_code", "suspend_timing"}
+        assert set(TUSHARE_SUSPEND_SCHEMA.keys()) == required_fields
+
+    def test_schema_types_are_polars_types(self) -> None:
+        """Schema values should be Polars String types."""
+        for dtype in TUSHARE_SUSPEND_SCHEMA.values():
+            assert dtype == pl.String
+
+    def test_ts_code_is_string(self) -> None:
+        """ts_code field should be String."""
+        assert TUSHARE_SUSPEND_SCHEMA["ts_code"] == pl.String
+
+    def test_suspend_timing_is_string(self) -> None:
+        """suspend_timing field should be String."""
+        assert TUSHARE_SUSPEND_SCHEMA["suspend_timing"] == pl.String

--- a/packages/datahub/tests/unit/meta/test_schemas_unit.py
+++ b/packages/datahub/tests/unit/meta/test_schemas_unit.py
@@ -8,6 +8,8 @@ from ditto_datahub.meta.schemas import (
     INDEX_WEIGHT_SCHEMA,
     STOCK_DAILY_SCHEMA,
     STOCK_STATUS_SCHEMA,  # B.3: Stock status schema
+    TUSHARE_LIST_STATUS_SCHEMA,  # Tushare source schemas
+    TUSHARE_ST_SCHEMA,  # Tushare source schemas
     UNIVERSE_CONSTITUENT_SCHEMA,
 )
 
@@ -295,3 +297,55 @@ class TestStockStatusSchema:
         assert STOCK_STATUS_SCHEMA["list_status"] == pl.Utf8
         assert STOCK_STATUS_SCHEMA["source"] == pl.Utf8
         assert STOCK_STATUS_SCHEMA["src_code"] == pl.Utf8
+
+
+class TestTushareSTSchema:
+    """Tests for TUSHARE_ST_SCHEMA."""
+
+    def test_schema_is_dict(self) -> None:
+        """Schema should be a dictionary."""
+        assert isinstance(TUSHARE_ST_SCHEMA, dict)
+
+    def test_schema_has_all_required_fields(self) -> None:
+        """Schema should have ts_code and name fields."""
+        required_fields = {"ts_code", "name"}
+        assert set(TUSHARE_ST_SCHEMA.keys()) == required_fields
+
+    def test_schema_types_are_polars_types(self) -> None:
+        """Schema values should be Polars String types."""
+        for dtype in TUSHARE_ST_SCHEMA.values():
+            assert dtype == pl.String
+
+    def test_ts_code_is_string(self) -> None:
+        """ts_code field should be String."""
+        assert TUSHARE_ST_SCHEMA["ts_code"] == pl.String
+
+    def test_name_is_string(self) -> None:
+        """name field should be String."""
+        assert TUSHARE_ST_SCHEMA["name"] == pl.String
+
+
+class TestTushareListStatusSchema:
+    """Tests for TUSHARE_LIST_STATUS_SCHEMA."""
+
+    def test_schema_is_dict(self) -> None:
+        """Schema should be a dictionary."""
+        assert isinstance(TUSHARE_LIST_STATUS_SCHEMA, dict)
+
+    def test_schema_has_all_required_fields(self) -> None:
+        """Schema should have ts_code and list_status fields."""
+        required_fields = {"ts_code", "list_status"}
+        assert set(TUSHARE_LIST_STATUS_SCHEMA.keys()) == required_fields
+
+    def test_schema_types_are_polars_types(self) -> None:
+        """Schema values should be Polars String types."""
+        for dtype in TUSHARE_LIST_STATUS_SCHEMA.values():
+            assert dtype == pl.String
+
+    def test_ts_code_is_string(self) -> None:
+        """ts_code field should be String."""
+        assert TUSHARE_LIST_STATUS_SCHEMA["ts_code"] == pl.String
+
+    def test_list_status_is_string(self) -> None:
+        """list_status field should be String."""
+        assert TUSHARE_LIST_STATUS_SCHEMA["list_status"] == pl.String


### PR DESCRIPTION
## 概述
Phase 3 低优先级代码简化任务，提取重复的 Schema 定义到常量。

### Task 3.3: Schema 常量提取
- 在 `meta/schemas.py` 中添加 3 个 Tushare Schema 常量
- 在 `sources/tushare/source.py` 中使用常量替换内联定义
- 新增 15 个单元测试，覆盖率 100%
- 提高代码一致性和可维护性

### 额外改进
- Code-simplifier 发现并添加了 `TUSHARE_SUSPEND_SCHEMA` 常量
- 确保所有三个 Tushare 辅助方法使用统一的模式

## 测试计划
- [x] 所有 922 个单元测试通过
- [x] 测试覆盖率 95.21%（超过 80% 要求）
- [x] Pre-commit 检查通过（ruff, mypy, bandit）
- [x] 规范审查通过
- [x] 代码质量审查通过

## 相关文件
- `packages/datahub/src/ditto_datahub/meta/schemas.py`
- `packages/datahub/src/ditto_datahub/meta/__init__.py`
- `packages/datahub/src/ditto_datahub/sources/tushare/source.py`
- `packages/datahub/tests/unit/meta/test_schemas_unit.py`