### PR TITLE
Document R5 governed quant research agent

### DIFF
--- a/docs/plans/2026-08-04-r4-portfolio-risk-design.md
+++ b/docs/plans/2026-08-04-r4-portfolio-risk-design.md
@@ -203,5 +203,5 @@ R4 交付 pre-trade（每单）+ EOD 全量重算 + daily-scan；持久化可恢
 
 - 路线图状态：`docs/reviews/2026-08-04-roadmap-status.md`
 - 全量审计：`docs/reviews/2026-08-04-comprehensive-architecture-audit.md`（§2.6 portfolio、§2.7 risk）
-- AI 能力平面：`docs/plans/2026-08-04-ai-agent-capability-plane-design.md`（R4 是 AI Phase C/D 的写入靶点根基）
+- 当前 R5 设计：`docs/plans/2026-08-12-r5-governed-quant-research-agent-design.md`（R4 是 R5 evidence 与 shadow decision 的确定性宿主）
 - 边界标准：`docs/architecture/boundaries-and-abstraction-standards.md`

--- a/docs/plans/2026-08-12-r5-governed-quant-research-agent-design.md
+++ b/docs/plans/2026-08-12-r5-governed-quant-research-agent-design.md
@@ -1,0 +1,534 @@
+# R5 治理型量化研究 Agent 设计
+
+> **日期**：2026-08-12
+> **状态**：Accepted，R5 设计事实源
+> **适用范围**：本机、内部、单操作者的 A 股日频研究与决策辅助
+> **取代**：[2026-08-04 AI/Agent 能力平面设计](archive/2026-08-04-ai-agent-capability-plane-design.md) 与 [2026-08-04 Phase A Copilot 计划](archive/2026-08-04-agent-capability-plane-phase-a-copilot.md)
+> **实施计划**：[2026-08-12 R5 详细实施计划](2026-08-12-r5-governed-quant-research-agent-implementation-plan.md)
+> **上游事实**：[架构快速参考](../architecture/agent-context-pack.md)、[边界与抽象标准](../architecture/boundaries-and-abstraction-standards.md)、[PIT 合同](../../.agents/skills/ditto-pit-safety/references/pit-contract.md)、[R4/G3 执行计划](2026-08-10-r4-portfolio-risk-g3-execution-plan.md)
+
+## 1. 决策摘要
+
+Ditto R5 建设的是**治理型量化研究与决策 Agent**，不是自动交易聊天机器人，也不是让多个 LLM 角色自由辩论后直接给出交易指令。
+
+R5 的生产架构采用：
+
+1. 一个 `ditto_agent` 能力包、一个主 Agent、一个确定性状态机。
+2. 模型只负责意图理解、假设提出、受控代码生成、证据归纳与解释。
+3. 数据可见性、回测、组合、风险、成本、显著性和执行资格由 Ditto 确定性宿主计算。
+4. 读操作自动执行；草案和受控研究写入按权限执行；任何具有外部影响或正式发布含义的写操作由 HITL 审批。
+5. R5.3 允许经一次人工审批后运行有预算、有边界、可恢复的自主研究 Campaign；该授权不能扩大到策略发布、实盘路径或券商操作。
+6. 多 Agent 只作为离线对照实验。没有量化增益证据前，不进入生产运行时。
+
+当前仓库已经具备 R5 的可靠宿主：R3 experiment/holdout/trial ledger/replay、R4 portfolio/risk/Daily Decision V3，以及 apps composition root。R5 的重点不是再造量化引擎，而是建立受治理的模型运行时、证据协议、研究授权、沙箱和评测体系。
+
+## 2. 当前事实与设计前提
+
+- 当前代码是 12 包 Python 模块化单体；R5 实施后增加第 13 个包 `ditto_agent`。
+- R4 与 G3 已由提交 `9ee6c48c`（PR #72）完成；`DailyDecisionV3QueryFacade`、风险投影和持久化 reader 已存在。
+- `ditto_analysis.experiments` 已拥有 experiment identity、fold、attempt、holdout、trial ledger、持久化合同和独立研究 SQLite。
+- `ditto_application.processes.experiments` 已拥有计划、调度、lease、恢复、walk-forward、holdout 和 evidence 编排。
+- `ditto_apps.registry` 是唯一 composition root；普通 API/CLI/Job 不得直接装配能力包实现。
+- 当前无 `openai-agents`、Langfuse 或 Agent 业务包生产依赖；OTel 基础已经存在。
+- R5 首发仍是本机、内部、单操作者；auth/RBAC、多租户和外部 Beta 属于 G4。
+
+## 3. 业界调研与方向校验
+
+### 3.1 调研方法
+
+调研优先使用项目仓库、官方文档、论文和监管机构原文。项目星数、宣传收益和 demo 结果不作为架构正确性的证据；重点比较运行时结构、研究闭环、数据时间语义、回测权威、沙箱、记忆、审批和发布边界。
+
+以下链接于 **2026-08-12** 复核。
+
+### 3.2 项目证据矩阵
+
+| 项目 | 可验证能力 | 值得采用 | Ditto 不照搬的部分 |
+|---|---|---|---|
+| [TradingAgents](https://github.com/TauricResearch/TradingAgents) | LangGraph 多角色分析、checkpoint resume、结构化输出和决策记忆 | 状态可恢复、角色职责显式、运行记录 | 自由辩论不是收益或安全证据；生产默认不采用多 Agent 投票 |
+| [RD-Agent](https://github.com/microsoft/RD-Agent) | 假设提出、代码实现、实验反馈、自演化式数据/模型研发 | 假设→实现→评价→反馈的受控循环 | 不在一次 Campaign 同时优化 factor 与 model；不接受模型自行声明改进 |
+| [Qlib](https://github.com/microsoft/qlib) / [PIT 文档](https://qlib.readthedocs.io/en/stable/advanced/PIT.html) | 研究工作流、模型、策略、组合、回测、实验记录和 PIT 数据 | 研究工件化、可复现实验、PIT 数据层 | 不引入第二套量化平台；Ditto 继续由自身数据、回测和风险语义裁决 |
+| [QuantaAlpha](https://github.com/QuantaAlpha/QuantaAlpha) | LLM 与演化策略结合的因子挖掘和验证轨迹 | 候选 lineage、演化预算、自动验证 | 不把搜索次数藏在分支中，不让 holdout 形成反馈梯度 |
+| [FinMem](https://github.com/pipiku915/FinMem-LLM-StockTrading) | 分层记忆、反馈和交易 Agent 状态 | 结构化、带时间的研究记忆 | 不把模型输出或收益结果自动提升为长期知识；记忆必须有 `known_at` |
+| [FinRobot](https://github.com/AI4Finance-Foundation/FinRobot) | 金融报告、估值、风险分析和多源工具 | 金融任务工具化、报告工件化 | 不让通用数据源和 Agent action 绕过 Ditto 数据许可、PIT 与 application facade |
+| [Freqtrade](https://github.com/freqtrade/freqtrade) | backtest、dry-run、lookahead-analysis、recursive-analysis | 先 dry-run、显式检测前视和递归偏差 | R5 不连接交易所或券商，不把 Agent 研究结果直接提升到交易策略 |
+| [NautilusTrader](https://github.com/nautechsystems/nautilus_trader) | 确定性事件驱动时间、研究—实盘语义一致、适配器隔离 | 确定性时钟、同一宿主语义、清晰 adapter 边界 | 不因 Agent 引入另一套时间或执行模型 |
+| [LEAN](https://github.com/QuantConnect/Lean) | 模块化事件驱动研究、回测、优化和实盘 | 策略与宿主职责分离、可插拔执行模型 | R5 生成代码只产出研究分数，不能获得订单和券商能力 |
+| [ai-hedge-fund](https://github.com/virattt/ai-hedge-fund) | 多角色股票分析的教育性实现 | 可作为自然语言任务集和 adversarial case 来源 | README 明确非真实交易系统；不作为生产架构或收益证据 |
+| [AlphaQuanter](https://aclanthology.org/2026.findings-acl.456/) | 单 Agent、tool-augmented workflow 与强化学习策略研究 | 单 Agent 基线、透明工具轨迹和端到端评测 | 不把交易 RL 或论文收益直接移入产品；必须在 Ditto 自有数据、PIT 和成本约束下重新评估 |
+
+### 3.3 Agent 平台与模型风险证据
+
+- [OpenAI Agents SDK](https://developers.openai.com/api/docs/guides/agents) 支持 code-first Agent、function tools、运行状态、guardrails、审批和自定义存储；官方也明确服务端仍拥有部署、工具实现、状态存储和审批决策。
+- [Guardrails 与人工审批](https://developers.openai.com/api/docs/guides/agents/guardrails-approvals) 支持中断并恢复同一运行；tool guardrail 必须放在产生副作用的工具边界，不能只依赖 Agent 首尾 guardrail。
+- [Agent evals](https://developers.openai.com/api/docs/guides/agent-evals) 建议先用 trace 定位工作流问题，再以 dataset/eval run 做可重复回归。Ditto 在此基础上增加 PIT、安全和财务结果的确定性 grader。
+- [OpenAI 数据控制](https://developers.openai.com/api/docs/guides/your-data) 说明默认 abuse monitoring 和部分 endpoint application state 的保留行为；MAM/ZDR 需要资格与项目配置，`store=false` 也不能替代 endpoint 级核验。
+- [NIST AI RMF Core](https://airc.nist.gov/airmf-resources/airmf/5-sec-core/) 与 [NIST Generative AI Profile](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf) 强调持续治理、测量、验证、记录和上下文内解释。
+- [Federal Reserve SR 26-2](https://www.federalreserve.gov/frrs/guidance/supervisory-guidance-on-model-risk-management.htm) 强调按模型用途和暴露度实施开发、验证、监控、治理与第三方模型管理。该指引不直接覆盖生成式/agentic AI，但其风险分级、独立验证和 outcome analysis 原则仍适合作为 Ditto 内部控制参考。
+- [FINRA Regulatory Notice 24-09](https://www.finra.org/rules-guidance/notices/24-09) 强调使用 GenAI 不免除既有监督、记录、隐私、可靠性和准确性义务。
+- [证监会《证券市场程序化交易管理规定（试行）》](https://www.csrc.gov.cn/csrc/c100028/c7480577/content.shtml) 与 [上交所实施细则](https://www.sse.com.cn/lawandrules/sselawsrules2025/trade/universal/c/c_20250612_10781696.shtml) 强调报告、全程管理、权限/阈值/异常监测、人工干预、测试和记录。R5 不属于获准自动下单系统；该边界必须在产品和代码中同时成立。
+
+### 3.4 调研裁决
+
+**采用：**
+
+- 单 Agent + 确定性工作流作为生产默认。
+- function tools 访问受控内部事实，模型不直接访问存储或券商。
+- 结构化假设、候选、评价、记忆、Episode 和审计工件。
+- 可恢复运行、预算和停止条件。
+- 生成代码在无网 OCI 沙箱运行，宿主计算所有财务结果。
+- 离线 eval、PIT sentinel、安全攻击和 shadow outcome analysis。
+
+**不采用：**
+
+- 以多 Agent 角色数量代表前沿程度。
+- LLM 直接计算收益、风险、权重或订单。
+- 首发开放 Web、RAG、MCP、Hosted Code Interpreter 或任意插件市场。
+- Agent 自主发布策略、修改生产配置或连接真实券商。
+- 把对话文本无条件转为长期记忆或训练反馈。
+- 用回测 holdout 的反复查看指导搜索。
+
+最终方向是当前金融 AI 工程的前沿实践：**模型负责不确定的语义与搜索，确定性金融宿主负责事实、时间、计算、权限和审计。**
+
+## 4. 产品边界
+
+### 4.1 用户与自治等级
+
+- 首发用户：内部、本机、单操作者。
+- 通用自治：governed advisory。Agent 可读、起草、校验和提出动作；正式写动作等待审批。
+- 研究自治：用户审批一个不可变 `CampaignAuthorization` 后，Agent 可在授权预算和单一搜索轴内自动生成、执行和评价多个研究候选。
+- 任何授权都不能隐式扩展到策略 publish、DailyDecision 修改、订单生成、真实数据写入或券商调用。
+
+### 4.2 R5.0—R5.5
+
+| 阶段 | 交付 | 生产权限 |
+|---|---|---|
+| R5.0 | 合同、状态机、模型 port、审计、Episode/replay、eval 基线 | Fake provider 为主，无业务写入 |
+| R5.1 | Evidence Copilot：研究、回测、组合、风险、DailyDecision V3 解读 | 只读 |
+| R5.2 | Author Copilot：StrategySpec/DSL/配置草案、校验和差异预览 | 草案；正式写入逐动作 HITL |
+| R5.3 | Autonomous Research Campaign：假设、候选代码、实验、反馈和研究记忆 | 一次审批后的受控研究写入 |
+| R5.4 | Decision Briefing：DailyDecision V3 之后生成 `DecisionOpinion` | Shadow-only，不影响决策或交易 |
+| R5.5 | 安全、评测、SLO、retention、降级和发布证据 | feature flags 默认关闭 |
+
+### 4.3 非目标
+
+- 真实券商连接、自动下单、策略自动发布和生产参数自动修改。
+- 公网服务、认证、RBAC、多租户和面向客户的投资建议。
+- 开放 Web/RAG/MCP、第三方 tool marketplace、Hosted Code Interpreter。
+- 任意宿主挂载、联网安装依赖或通用 Notebook 执行。
+- R5 生产多 Agent、强化学习交易、分钟级交易或全球资产扩展。
+
+## 5. 架构与所有权
+
+### 5.1 依赖图
+
+```text
+ditto_apps ──> ditto_agent ──> ditto_application ──> capability packages
+     └──────────────────────> ditto_application
+
+ditto_platform = 横向技术基础设施
+ditto_kernel   = 最小稳定原语
+```
+
+`ditto_agent` 不是 application 的 peer，也不是 capability 包的入口替代品。它位于 apps 与 application 之间，消费 application 暴露的用例合同。
+
+### 5.2 四要素边界
+
+| 能力平面/owner | provider/实现 | 直接消费者 | 跨边界合同 |
+|---|---|---|---|
+| `ditto_agent` 运行时 | 单 Agent 状态机、Agents SDK adapter、Agent SQLite | apps API/CLI、registry | `AgentModelPort`、Agent contracts、Agent store ports |
+| `ditto_application.queries` | 既有及新增 evidence facade | `ditto_agent.tools` | 叶级 query/read-model |
+| `ditto_application.commands/processes` | 草案命令、Campaign coordinator、可信 evaluator | `ditto_agent.tools` | command/process DTO、`CandidateSandboxPort` |
+| `ditto_analysis.experiments` | 研究领域对象与独立 SQLite adapter | application experiment processes | research contracts、reader/writer protocols |
+| `ditto_apps.registry.agent` | 配置加载、OpenAI runtime 装配、OCI sandbox adapter | apps API/CLI | consumer-owned ports 的具体实现 |
+| `ditto_platform` | SQLite/OTel/clock/serialization 技术原语 | agent/analysis/application/apps | 业务无关的既有技术合同 |
+
+### 5.3 机器边界
+
+实施时将 `ditto_agent` 加入 `.importlinter` root packages，并至少建立：
+
+1. `agent-capability-isolation`：禁止 `ditto_agent` 导入 data/features/strategy/portfolio/risk/execution/backtest/analysis。
+2. `application-no-agent`：禁止 `ditto_application` 反向导入 `ditto_agent`。
+3. `capabilities-no-agent`：所有业务能力包禁止导入 `ditto_agent`。
+4. `platform-no-agent`：platform 禁止依赖 Agent 业务概念。
+5. `agent-no-apps`：`ditto_agent` 禁止依赖 apps。
+6. apps 非 registry 路径不得直接导入 Agent 的物理 storage/provider/sandbox adapter。
+
+消费者从定义符号的叶模块导入，不通过跨包 re-export、`TYPE_CHECKING`、延迟导入或 service locator 掩盖方向。
+
+### 5.4 模型与基础设施放置
+
+- `AgentModelPort` 及 OpenAI Agents SDK adapter 位于 `ditto_agent.models`，因为它们服务于 Agent runtime，不是通用平台能力。
+- Fake model 与 deterministic scripted model 同样实现该 port，测试默认不调用云端。
+- Agent 业务 SQLite schema、reader、writer 和 audit chain 位于 `ditto_agent.storage.sqlite`。
+- 环境变量、OpenAI project、模型 profile、OTel exporter 和 sandbox runtime 配置只在 `ditto_apps.registry` 读取并注入。
+- 不新增 `ditto_platform.services.llm` 一类通用 LLM Gateway。
+
+## 6. 公共领域合同
+
+### 6.1 Agent-owned 类型
+
+| 类型 | 必需语义 |
+|---|---|
+| `AgentManifest` | agent/prompt/tool schema/model profile 的版本和摘要 |
+| `AgentSession` | 本地会话身份、创建时间、retention class；不充当长期研究事实 |
+| `AgentRun` | 状态、目标、authority、预算、model profile、manifest hash、开始/结束时间 |
+| `AgentEvent` | 单调 `event_id`、run_id、event type、payload hash、发生时间、prev hash |
+| `TemporalToolContext` | 由服务端注入的完整可见性、授权和数据外发上下文 |
+| `EvidenceEnvelope` | tool 结果、artifact refs、snapshot、时间边界、lineage、完整性 hash |
+| `GroundedAnswer` | 结论、逐结论 evidence refs、不确定性、缺失证据、拒答原因 |
+| `ApprovalRequest` | action kind、规范化参数、action hash、过期时间、所需权限 |
+| `CampaignAuthorization` | immutable campaign hash、预算、搜索轴、工具白名单和有效期 |
+| `AgentEpisodeManifest` | 输入、模型/prompt/tool 版本、事件、调用、结果和 replay identity |
+| `DecisionOpinion` | DailyDecision V3 的只读解释、异议、证据和 shadow outcome identity |
+
+### 6.2 Analysis-owned 类型
+
+| 类型 | 必需语义 |
+|---|---|
+| `ResearchCampaignManifest` | 预注册目标、搜索空间、validation protocol、预算和 lineage root |
+| `SearchLedger` | operational attempts、statistical trials、fork/retry lineage |
+| `HypothesisSpec` | 可证伪假设、机制、目标 universe、预期信号和失败条件 |
+| `CandidateSpec` | 单一 search axis、父候选、代码/参数 hash、数据需求 |
+| `ExperimentPlan` | folds、purge/embargo、成本、seed、snapshot、评价目标 |
+| `EvaluationResult` | 宿主计算指标、约束、显著性、失败分类和证据引用 |
+| `ResearchFeedback` | 可供下一代使用的结构化、非 holdout 反馈 |
+| `KnowledgeItem` | scope、claim、evidence refs、`outcome_known_at`、状态和 promotion |
+| `ResearchCodeArtifact` | 代码、AST hash、依赖清单、image digest、输入/输出 schema |
+| `SandboxExecutionManifest` | runtime digest、资源限制、输入输出 hash、退出状态和 attestation |
+
+这些对象必须可在没有 Agent runtime 的情况下被研究域读取和验证；analysis 不负责调度。
+
+### 6.3 `TemporalToolContext`
+
+所有 PIT-sensitive tool 必须接收服务端生成且模型不可覆盖的：
+
+```text
+decision_time             offset-aware，规范化为 UTC
+knowledge_cutoff          系统在决策时可知的最晚时间
+publication_cutoff        允许使用的最晚发布时间
+source_snapshot_id        不可为空的修订宇宙身份
+execution_eligible_at     信号最早可执行时间；纯研究读取也需显式为 not_applicable
+allowed_universe          允许证券集合或其不可变摘要
+license_class             数据使用权等级
+egress_class              cloud_allowed / local_only / prohibited
+campaign_authorization_id 可空；研究自治时必需
+campaign_authority_hash   可空；研究自治时必需
+```
+
+缺少 cutoff、snapshot、version metadata 或授权时 fail closed，禁止回退到 latest 或 wall-clock `now`。
+
+## 7. PIT、回测与研究真实性
+
+### 7.1 四个时间维度
+
+- observation/effective time：事实描述市场的时间。
+- publication/knowledge time：系统能够知道事实的时间。
+- source snapshot：可见修订版本宇宙。
+- execution time：信号可以成为订单或成交的最早时间。
+
+所有 request、cache key、artifact、Episode、Campaign、candidate 和 replay identity 都包含相关时间与 snapshot。
+
+### 7.2 计算规则
+
+- 版本有效性使用半开区间：`effective_from <= as_of < effective_to`。
+- as-of join 只能按 knowledge time 做 backward join，并按完整实体键分区、显式排序。
+- T 行只有在决策时已知才可参与计算；否则时间 rolling 左闭，点数 rolling 先 `shift(1)`。
+- 使用 T 日收盘信息的信号不能在同一收盘价成交，除非数据与执行合同显式证明可行。
+- 所有 R5.3 测试加入 cutoff 外极值 sentinel 与 cutoff 内相邻可用记录。
+
+### 7.3 权威计算边界
+
+LLM 或生成代码不得输出可被采信的收益、回撤、IC、风险、权重、订单或显著性。可信宿主负责：
+
+- fold/purge/embargo 和一次性 holdout；
+- 数据读取、PIT 过滤和 snapshot 传播；
+- backtest、交易成本、组合构建、风控和执行模拟；
+- 评价指标、多重检验、PBO/DSR 等既有统计控制；
+- evidence、artifact、lineage 和 replay。
+
+## 8. Agent 运行时与授权
+
+### 8.1 单 Agent 状态机
+
+Agent Run 状态：
+
+```text
+QUEUED -> RUNNING -> COMPLETED
+                   -> WAITING_APPROVAL -> RUNNING
+                   -> PAUSED -> RUNNING
+                   -> FAILED
+                   -> CANCELLED
+```
+
+状态转换由确定性 host 决定，模型只返回结构化 intent。非法转换、过期 lease、重复终态写入和 action hash 不一致全部 fail closed。
+
+### 8.2 工具权限
+
+| 工具类别 | 示例 | 默认权限 | 审批 |
+|---|---|---|---|
+| Evidence read | experiment、factor、portfolio、risk、DailyDecision V3 | 自动 | 无 |
+| Draft/validate | StrategySpec/DSL 草案、compile、diff、preview | 自动 | 不写正式状态 |
+| Formal author write | 保存草案、提交 review 等 application command | 禁止 | 每个 action hash 审批 |
+| Campaign internal | 创建候选、排队 fold、记录 feedback/memory | 禁止 | 一次 Campaign hash 审批后在预算内允许 |
+| Holdout | 一次性聚合评价 | 禁止 | 独立人工审批，不被 Campaign 授权覆盖 |
+| Publish/trading | publish、权重、订单、券商 | 不注册 | R5 永不允许 |
+
+审批 hash 至少覆盖 `action_kind`、tool、规范化参数、temporal context、snapshot、subject identity、预算、权限和 expiry。任一字段改变都创建新审批，不能重用旧决定。
+
+### 8.3 故障与恢复
+
+- 创建操作使用 `Idempotency-Key`，服务端保存 key、request hash 和 result identity。
+- 运行和 Campaign 使用 lease；lease 到期只能由持有恢复权限的协调器接管。
+- 模型超时、限流或不可用时停止新增动作，保留已完成证据并进入 `PAUSED` 或结构化 `FAILED`。
+- approval 状态序列化到 Ditto 本地 store；恢复时仍验证 action hash、authority 和过期时间。
+
+## 9. Autonomous Research Campaign
+
+### 9.1 不可变授权
+
+`ResearchCampaignManifest` 在审批前 canonicalize 并生成 SHA-256。审批后的 `CampaignAuthorization` 固定：
+
+- 目标和主评价指标；
+- 数据 snapshot、universe、PIT protocol；
+- 单一 `search_axis`；
+- 候选/fold/时间/存储/并发/模型费用预算；
+- 可调用工具和禁止动作；
+- stopping rule、有效期和授权人。
+
+改变任一字段会生成新 Campaign，不允许在运行中扩大权限。
+
+### 9.2 默认预算
+
+| 维度 | 默认上限 |
+|---|---:|
+| generations | 6 |
+| unique evaluated candidates | 128 |
+| fold runs | 384 |
+| concurrent sandboxes | 2 |
+| wall time | 4 小时 |
+| temporary storage | 20 GiB |
+| LLM spend | 8 美元 |
+| per sandbox CPU | 2 vCPU |
+| per sandbox memory | 4 GiB |
+
+连续两代 validation 主指标没有改善时停止。预算耗尽进入 `PAUSED_BUDGET`，不能自动加额。
+
+### 9.3 单一搜索轴
+
+`search_axis` 只能是：
+
+- `factor_code`（默认）；
+- `model_code`；
+- `parameters`。
+
+一个 R5 Campaign 不做 factor-model co-optimization。需要切换轴时结束当前 Campaign，并以已批准的正式工件作为新 Campaign 基线。
+
+### 9.4 SearchLedger
+
+- operational attempt：执行同一 immutable trial 的重试、恢复或基础设施尝试。
+- statistical trial：唯一 `candidate_hash × validation_protocol_hash`，无论重试几次只计一次。
+- fork/retry 保留同一 lineage root 和 family counter，不能通过分叉重置 multiple-testing。
+- 候选去重同时使用 canonical AST hash、输出相关性和 lineage。
+
+### 9.5 Holdout
+
+- holdout 数据、日期、逐期结果和中间特征不进入 Agent context、tool 输出或研究 memory。
+- 一个预选 candidate 只有一次人工批准的 holdout claim。
+- 只返回签名的 aggregate pass/fail、预注册门槛结果和 evidence hash。
+- holdout 结果不能成为下一代搜索、prompt 或 `KnowledgeItem` 的输入。
+
+### 9.6 研究记忆
+
+scope 为 `campaign-local`、`strategy-family`、`global`；默认 local。每条 `KnowledgeItem` 必须有来源、claim、适用范围、`outcome_known_at`、snapshot 和状态。
+
+- 读取条件：`outcome_known_at <= TemporalToolContext.knowledge_cutoff`。
+- local 提升到 family/global 需要人工审批和独立证据。
+- 失效、矛盾和撤销为 append-only 状态，不覆盖历史。
+- 模型自评、未验证解释和 holdout 结果不得成为长期记忆。
+
+## 10. 生成代码与沙箱
+
+### 10.1 代码合同
+
+```python
+fit(training_stream) -> ModelStateArtifact
+score(visible_window, immutable_model_state) -> CandidateScoreFrame
+```
+
+- `training_stream` 和 `visible_window` 只包含当前 fold、当前 cutoff、当前 snapshot 可见的数据。
+- `ModelStateArtifact` 必须不可变、内容寻址且使用批准的 JSON/Arrow/NumPy 格式。
+- `CandidateScoreFrame` 只包含 identity、time 和 score/prediction；不含收益、权重、订单和评价指标。
+- `score` 不得写外部状态；同一输入、状态、image digest 和 seed 得到相同输出。
+
+### 10.2 OCI 安全基线
+
+- macOS 开发机：Docker Desktop VM 内运行；Linux：rootless OCI，优先以 gVisor 等额外隔离 runtime 验证。
+- 无网络、无 socket、无 Docker socket、无 repo/host mounts、无 secret/env 凭证。
+- non-root、read-only rootfs、tmpfs scratch、cap-drop ALL、no-new-privileges、seccomp。
+- 固定 image digest、SBOM 和依赖集合；禁止 `pip install` 或动态下载。
+- CPU、memory、PID、disk、wall time、stdout/stderr、输入输出大小均有限额。
+- 禁止 pickle；NumPy 强制 `allow_pickle=False`；Arrow/JSON 解码做 schema 与大小校验。
+- 每个 candidate/fold 新建沙箱；同一 fold 内允许宿主按因果顺序多次调用 `score`，模型状态不可被就地修改。
+
+必须测试：fresh/reused runner、不同 candidate 顺序、fold 顺序和并发度下输出一致；网络、文件、进程、资源炸弹、恶意序列化和输出协议攻击全部失败。
+
+### 10.3 晋级边界
+
+生成代码永久首先是 `ResearchCodeArtifact`。进入正式 Ditto strategy/features 代码只能由人审查后创建独立 PR，重新经过 TDD、PIT、architecture、CI 和策略治理。R5 runtime 不动态加载研究代码到 EOD 或交易进程。
+
+## 11. API、SSE 与 CLI
+
+### 11.1 API
+
+```text
+POST /api/v1/agent/sessions
+POST /api/v1/agent/runs
+GET  /api/v1/agent/runs/{run_id}
+GET  /api/v1/agent/runs/{run_id}/events
+POST /api/v1/agent/approvals/{approval_id}/decision
+
+POST /api/v1/agent/campaigns
+POST /api/v1/agent/campaigns/{campaign_id}/approve
+GET  /api/v1/agent/campaigns/{campaign_id}
+POST /api/v1/agent/campaigns/{campaign_id}/cancel
+```
+
+- `POST` 创建操作要求 `Idempotency-Key`；相同 key 不同 body 返回 conflict。
+- request/response DTO 只在 apps；业务 contracts 从 owner 叶模块导入。
+- API 不接收模型提供的 `TemporalToolContext`，而是从服务端查询参数、配置和 authority 构造。
+- approval decision 只允许 `approve`/`reject`，记录 operator、理由、时间和目标 action hash。
+
+### 11.2 SSE
+
+- `GET .../events` 返回 `text/event-stream`。
+- 每个 run/campaign 的 `event_id` 单调递增且持久化。
+- 客户端可用 `Last-Event-ID` 继续；服务端重放缺失事件而不是重新运行工具。
+- heartbeat 不写业务事件；业务 event 包含 schema version 和 payload hash。
+
+### 11.3 CLI
+
+首批命令固定为：
+
+```text
+ditto agent run
+ditto agent show RUN_ID
+ditto agent events RUN_ID --follow
+ditto agent approve APPROVAL_ID
+ditto agent reject APPROVAL_ID
+ditto agent campaign create MANIFEST
+ditto agent campaign approve CAMPAIGN_ID
+ditto agent campaign show CAMPAIGN_ID
+ditto agent campaign cancel CAMPAIGN_ID
+```
+
+CLI 只调用同一 application/agent runtime，不另建同步执行旁路。
+
+## 12. 模型、数据外发与可观测性
+
+### 12.1 模型 profile
+
+| profile | 模型 | reasoning | 用途 |
+|---|---|---|---|
+| balanced | `gpt-5.6-terra` | medium | 默认解释、工具选择、普通草案 |
+| quality | `gpt-5.6-sol` | high | 高难度研究假设、代码生成、独立复核 |
+
+profile 映射、模型 snapshot、prompt 和 tool schema 必须版本化；变更后完整重跑相关 eval。实际可用模型和成本在实施审批时再次按 [OpenAI 官方模型目录](https://developers.openai.com/api/docs/models) 核验。
+
+### 12.2 OpenAI 数据边界
+
+- 使用专用 OpenAI project，不使用 default project。
+- 上线真实模型前必须确认该 project 已获 MAM 或 ZDR；所有 Responses 请求显式 `store=false`。
+- 只允许 `egress_class=cloud_allowed` 且 license 允许的 evidence 进入模型。
+- 首发禁用 Conversations、Files、Vector Stores、Background mode、Hosted Code Interpreter/Shell、Web Search、MCP 和远程 connectors。
+- 不依赖 OpenAI 托管状态恢复；Ditto 本地 store 保存必要的脱敏状态和 encrypted reasoning continuation item（如 SDK/API 要求）。
+- OpenAI `/v1/evals` 不是 R5 发布证据的唯一存储；ZDR 项目下正式 eval 以 Ditto 本地 dataset、Episode 和 grader 为事实源。
+
+### 12.3 OTel 与审计
+
+OTel 是主协议，Langfuse 只可作为可选 exporter，不能成为 Agent 运行依赖。每个 run 记录：
+
+- trace/run/session/campaign identity；
+- model/profile/prompt/tool schema/image digest；
+- tool name、规范化参数 hash、authority、temporal context、结果 hash；
+- guardrail、approval、budget、retry、latency、token 和 cost；
+- artifact/evidence refs、最终状态和人工反馈。
+
+审计事件使用本地 tamper-evident hash chain；不得把 secret、API key、完整持仓敏感内容或禁止外发的原始数据写入 trace。
+
+### 12.4 留存
+
+- 默认不保存完整敏感 prompt/response；先脱敏并保存结构化摘要、hash 和 evidence refs。
+- 经配置允许保存的原始运行内容保留 30 天，由本地 cleanup job 删除。
+- 正式研究工件、审批、Episode manifest、审计摘要和 hash chain 长期保存。
+- 如未来需要保存完整原文，先完成静态加密、密钥管理、恢复和删除验证；该能力不在 R5 默认实现中。
+
+## 13. 评测、SLO 与发布门
+
+### 13.1 120 条正式用例
+
+| 类别 | 数量 | 重点 |
+|---|---:|---|
+| grounded evidence | 30 | 工具选择、证据覆盖、引用、拒答 |
+| author | 20 | StrategySpec/DSL 草案、compile、validate、diff |
+| campaign/PIT/holdout | 30 | snapshot、sentinel、trial ledger、holdout 隔离 |
+| permission/approval | 20 | 越权、hash 篡改、过期、恢复、幂等 |
+| sandbox attacks | 10 | 网络、挂载、资源、序列化、逃逸 |
+| shadow decision | 10 | V3 grounding、只读、不影响下游 |
+
+### 13.2 硬门
+
+- 禁止动作、PIT future sentinel、审批绕过、holdout 泄漏、sandbox escape：100%。
+- tool choice、evidence coverage：至少 95%。
+- factual correctness：至少 90%。
+- 必须拒答场景：100%。
+- Author compile/validate：至少 90%。
+- 相同 Episode 的 tool/event replay：100% 确定。
+- 任何模型、prompt、tool schema、routing 或 guardrail 变更都重跑受影响数据集；安全/PIT 指标零回退。
+
+### 13.3 交互预算
+
+- 普通 read：P95 ≤ 30 秒，单次模型成本 ≤ 0.25 美元。
+- 复杂任务：P95 ≤ 60 秒，单次模型成本 ≤ 0.75 美元。
+- Campaign 使用自身总预算，不以交互任务预算替代。
+
+### 13.4 多 Agent ADR 触发条件
+
+只有在同一 Episode 集上相对单 Agent：
+
+- task success 提高至少 5 个百分点，或 candidate acceptance 提高至少 10%；
+- safety、PIT、approval 指标无回退；
+- cost 和 latency 均不超过 2 倍；
+
+才允许提出生产多 Agent ADR。达到门槛不等于自动采用，仍需架构与运营审批。
+
+## 14. 监管与控制映射
+
+| 控制目标 | R5 设计 |
+|---|---|
+| 治理和责任 | owner 明确、feature flag、审批、release evidence、变更 eval |
+| 模型验证 | 固定 dataset、独立确定性 grader、shadow outcome analysis |
+| 第三方模型风险 | 专用 project、版本记录、MAM/ZDR、egress policy、provider 可替换 port |
+| 记录和可追溯 | Episode、OTel、artifact refs、hash-chain audit、retention |
+| 权限和人工干预 | tool allowlist、action hash、HITL、cancel/pause、fail closed |
+| 程序化交易隔离 | 不注册 publish/order/broker tools；DecisionOpinion shadow-only |
+| 系统安全 | OCI 隔离、资源限额、无网无挂载、攻击测试、runbook |
+| 数据许可与隐私 | license/egress class、脱敏、最小外发、禁用托管状态能力 |
+
+该映射用于内部工程治理，不构成法律意见或对外合规声明。进入 G4/G5 前必须由适格法律与合规人员复核具体使用方式。
+
+## 15. 降级、开关与完成定义
+
+所有 R5 feature flags 默认 `false`。Agent provider、OTel exporter、Agent SQLite 或 sandbox 不可用时：
+
+- Ditto 核心 data/research/backtest/portfolio/risk/execution 和 DailyDecision 继续运行。
+- Agent API 返回结构化 unavailable/paused，不回退为无证据回答。
+- 已经持久化的审批、Campaign 和事件保持可恢复，不自动重放副作用。
+
+R5 完成要求：
+
+1. R5.0—R5.5 各波次 exit gate 全部通过。
+2. 120 条正式 eval 达到硬门且留有可重放 evidence。
+3. PIT、holdout、sandbox、approval 和禁止交易路径均有 adversarial 证据。
+4. 交互 SLO、成本、retention、备份恢复、降级和 runbook 验收通过。
+5. 设计、源码、OpenAPI、CLI、`.importlinter` 和 release evidence 一致。
+6. 未满足 G4 时仍维持本机、内部、单操作者和非自动交易边界。

--- a/docs/plans/2026-08-12-r5-governed-quant-research-agent-implementation-plan.md
+++ b/docs/plans/2026-08-12-r5-governed-quant-research-agent-implementation-plan.md
@@ -1,0 +1,911 @@
+# R5 治理型量化研究 Agent 详细实施计划
+
+**日期：** 2026-08-12
+**状态：** 未开始
+**恢复点：** Wave 0 / Task 1，先核对当前 R4/R3/application 叶级合同
+**设计事实源：** [R5 治理型量化研究 Agent 设计](2026-08-12-r5-governed-quant-research-agent-design.md)
+
+## 目标
+
+在不改变 Ditto 核心量化、DailyDecision 或交易权威的前提下，交付一个本机、内部、单操作者的治理型 Agent 平面：
+
+- grounded Evidence Copilot；
+- 带 compile/validate/diff 的 Author Copilot；
+- 一次审批、预算受限的 Autonomous Research Campaign；
+- DailyDecision V3 之后的 shadow-only Decision Briefing；
+- 可恢复状态、HITL、PIT、OCI 沙箱、OTel、审计、eval 和降级。
+
+成功边界以设计文档 §15 和本文 Wave 6 exit gate 为准。
+
+## 约束与不做事项
+
+- 当前基线：12 包；R4/G3 提交 `9ee6c48c` 已落地；R3 experiment/holdout/ledger/replay 可复用。
+- 新包：`packages/agent`，import name `ditto_agent`，实施后共 13 包。
+- 依赖方向：`apps -> agent -> application -> capabilities`；agent 不直接访问 capability 或 analysis。
+- `analysis` 只拥有研究领域和持久化合同；调度在 application；物理模型/沙箱装配在 apps registry。
+- PIT 缺少 cutoff/snapshot/version 时 fail closed；禁止 latest fallback。
+- 数据帧继续使用 Polars；依赖只经 Pixi；序列化优先 orjson，禁止 pickle。
+- 不实现公网、auth/RBAC、多租户、Web/RAG/MCP、Hosted Code Interpreter、真实券商、自动下单或自动策略发布。
+- 生成代码不进入 EOD/交易动态加载路径。
+- 所有 Agent feature flags 默认关闭，Agent 故障不能影响核心 Ditto。
+
+## 所需 Ditto skills
+
+- 所有公共合同、包边界、DI 和 `.importlinter`：`ditto-architecture-change`。
+- 所有行为任务：`ditto-test-first`，先观察能够解释目标行为的 RED。
+- 数据查询、Campaign、生成代码、fold、memory、holdout：`ditto-pit-safety`。
+- 高风险 diff 完成后及 PR 前：`ditto-change-review`。
+
+纯文档和机械归档不要求 RED；生产 Python、schema、架构和交易语义任务不能豁免。
+
+## 固定目录与接口放置
+
+| 边界 | 固定位置 |
+|---|---|
+| Agent contracts/runtime/tools/models/storage/evals | `packages/agent/src/ditto_agent/**` |
+| Agent 单元测试 | `packages/agent/tests/unit/**` |
+| Evidence queries | `packages/application/src/ditto_application/queries/{research_evidence,decision_evidence}.py` |
+| Campaign orchestration/ports | `packages/application/src/ditto_application/processes/experiments/{autonomous_campaign,candidate_sandbox_port,generated_candidate_evaluator}.py` |
+| Research campaign domain | `packages/analysis/src/ditto_analysis/experiments/{campaign,generated_code,research_memory,search_ledger}.py` |
+| Research persistence | `packages/analysis/src/ditto_analysis/storage/sqlite/experiments/**`，复用 `data_root/research/research.sqlite` |
+| Agent persistence | `packages/agent/src/ditto_agent/storage/sqlite/**`，固定 `data_root/agent/agent.sqlite` |
+| OpenAI/OCI/Agent composition | `packages/apps/src/ditto_apps/registry/agent/**` |
+| HTTP DTO/routes | `packages/apps/src/ditto_apps/models/agent.py`、`api/routes/agent_routes.py` |
+| CLI | `packages/apps/src/ditto_apps/cli/commands/agent.py` |
+
+不得为了方便改成 platform LLM gateway、agent 直连 analysis，或 apps route 直连 SQLite。
+
+## 执行合同
+
+1. 从 `codex/r5-governed-agent` 或同等非 `main` 分支开始；每个 Task 是独立可回滚提交。
+2. 每个行为 Task 先增加测试并运行精确命令观察 RED；记录失败原因后才实现 GREEN。
+3. schema、生产依赖、架构边界、OCI 和真实模型外发按 Approval 表暂停。
+4. Fake/scripted model 是默认测试 provider；普通 CI 不需要 API key、Docker daemon 或网络。
+5. 任何 live model/sandbox acceptance 独立标记并保存 evidence，不能替代 deterministic tests。
+6. 每个 Task 完成后在本文“恢复状态”记录提交、命令与结果；不得用历史 GREEN 替代当前 diff。
+
+## Tasks
+
+### Wave 0：前置确认与批准
+
+### Task 1：冻结当前 R3/R4/application 消费面
+
+**依赖：** 无
+**风险：** 普通，只读
+**状态：** [ ]
+
+- **目标文件或边界：** `DailyDecisionV3QueryFacade`、experiment query/command/process、StrategySpec/DSL、portfolio/risk read model、apps registry provider。
+- **RED/观察证据：** 用 `rg` 和类型签名列出真实叶模块；若设计文档中的任何符号不存在，记录 mapping，不靠 re-export 或猜测补齐。
+- **实施：** 生成 `docs/evidence/r5/preflight/current-contract-inventory.md`，逐项记录 provider、consumer、方法签名、PIT 字段和复用/新增裁决。
+- **重构边界：** 本 Task 不改生产代码。
+- **验收：** inventory 覆盖 R5.1—R5.4 所有工具所需合同，且每个新增 facade 都有明确理由。
+- **提交边界：** 只提交 preflight evidence。
+- **恢复入口：** inventory 中第一项 `missing` 或 Task 2。
+
+```bash
+rg -n "DailyDecisionV3|Experiment|Holdout|TrialLedger|StrategySpec|FactorEvaluation|RiskGate" packages/application/src packages/analysis/src packages/apps/src
+git diff --check
+```
+
+### Task 2：冻结 SDK、模型和 OCI 技术证据
+
+**依赖：** Task 1
+**风险：** 普通，只读；结论触发后续审批
+**状态：** [ ]
+
+- **目标文件或边界：** OpenAI Agents SDK 当前 Python API、Responses `store=false`、MAM/ZDR、模型 profile、Docker Desktop/rootless OCI/gVisor 能力。
+- **RED/观察证据：** 当前项目没有 `openai-agents` 直接依赖；不得依赖历史 2026-08-04 的示例签名。
+- **实施：** 写 `docs/evidence/r5/preflight/runtime-dependency-proof.md`，记录精确包版本范围、上游链接、所需 SDK API、license、transitive review、模型 ID 和 OCI feature matrix。
+- **重构边界：** 不安装依赖、不拉镜像、不创建 project。
+- **验收：** 能回答 Agents SDK adapter、mock 方式、approval state serialization、OTel bridge、macOS/Linux sandbox 差异。
+- **提交边界：** 只提交 dependency proof。
+- **恢复入口：** Approval A1。
+
+```bash
+rg -n "openai|agents|langfuse|opentelemetry|docker" pixi.toml pyproject.toml packages/*/pyproject.toml pixi.lock
+git diff --check
+```
+
+### Task 3：收集四类批准证据
+
+**依赖：** Task 2
+**风险：** 高风险，暂停点
+**状态：** [ ]
+
+- **目标文件或边界：** Approval A1—A4。
+- **RED/观察证据：** 任一批准为空即阻塞对应 Task，不把本文设计接受等同于未来生产依赖/schema/外发批准。
+- **实施：** 在 `docs/evidence/r5/preflight/approvals.md` 记录批准人、时间、精确对象、版本/hash、限制和撤销条件。
+- **重构边界：** 未批准的 Wave 可继续做只读设计或 Fake provider 工作，但不能越过对应 Gate。
+- **验收：** Approval 表所有必填字段可审计。
+- **提交边界：** 单独 evidence 提交；不与依赖或 schema 变更混合。
+- **恢复入口：** Task 4，或具体外部等待项。
+
+```bash
+git diff --check
+```
+
+### Wave 1：R5.0 治理基础
+
+### Task 4：建立 `ditto_agent` 包和机器边界
+
+**依赖：** Task 3 / Approval A1
+**风险：** 高风险，架构和生产依赖
+**状态：** [ ]
+
+- **目标文件或边界：** `packages/agent/{pyproject.toml,AGENTS.md,src/ditto_agent,tests}`、`pixi.toml`、`.importlinter`、架构文档。
+- **RED/观察证据：** 先增加 import/boundary tests，观察 `ditto_agent` 不存在或缺少机器合同。
+- **实施：** 添加 `openai-agents` 精确上限；建立 typed 空包；加入 root packages 和 agent/application/capability/platform/apps forbidden contracts；Pixi 注册 editable package。
+- **重构边界：** 不添加 LLM gateway、业务工具或 storage；不更改既有 capability 方向。
+- **验收：** 包可导入，非法 fixture import 被 contract 拦截，全部现有合同保持通过。
+- **提交边界：** 仅包骨架、依赖和机器边界。
+- **恢复入口：** 首个失败的 import-linter contract。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_package_boundary.py -v
+pixi run -e dev arch-check
+pixi run -e dev check
+```
+
+### Task 5：核心合同、canonical codec 与状态机
+
+**依赖：** Task 4
+**风险：** 行为/公共契约
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.contracts.{runtime,temporal,evidence,approval}`、`runtime.{codec,state_machine}`。
+- **RED/观察证据：** 先测试 Run 合法/非法转换、UTC/enum/identity 校验、canonical bytes 稳定性和 action hash 篡改。
+- **实施：** 落地设计文档中的 Agent-owned types；canonical encoding 固定字段顺序、Unicode/number/datetime 规范；审批 hash 覆盖 authority、PIT、snapshot、预算和 expiry。
+- **重构边界：** 类型不含 I/O；模型不能构造受信 `TemporalToolContext`。
+- **验收：** 相同语义跨字段顺序 hash 相同；任一安全字段改变 hash 必变；非法状态 fail closed。
+- **提交边界：** 核心纯合同和单元测试。
+- **恢复入口：** 第一个未通过的 golden codec fixture。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_contracts.py packages/agent/tests/unit/test_state_machine.py packages/agent/tests/unit/test_canonical_codec.py -v
+pixi run -e dev check
+```
+
+### Task 6：`AgentModelPort`、Fake provider 与 OpenAI adapter
+
+**依赖：** Task 5；真实调用另依赖 Approval A4
+**风险：** 行为/第三方 adapter
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.models.{port,fake,openai_adapter}`、`ditto_apps.registry.agent.model_provider`。
+- **RED/观察证据：** 先以 shared contract suite 证明 Fake 与 adapter 未实现 typed response、usage、interruptions 和 continuation state。
+- **实施：** port 只暴露 Agent runtime 需要的 run/stream/resume 语义；Fake 支持 scripted tool calls/failures；OpenAI adapter 固定 `store=false`、允许 function tools，拒绝禁用 hosted tools。
+- **重构边界：** API key/config 只由 apps 注入；不在 platform 建 gateway；测试不发网络请求。
+- **验收：** 两个 provider 通过相同 contract；禁用能力在构造或调用前 fail closed；usage 可计量。
+- **提交边界：** model port、providers、registry wiring 和测试。
+- **恢复入口：** shared provider contract 的第一处差异。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_model_port_contract.py packages/agent/tests/unit/test_openai_adapter.py packages/apps/tests/unit/test_agent_model_provider.py -v
+pixi run -e dev check
+```
+
+### Task 7：Agent SQLite、幂等、lease 与 hash-chain audit
+
+**依赖：** Task 5 / Approval A2
+**风险：** 高风险，schema/持久化
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.storage.sqlite.{database,schema,reader,writer,audit}`、`schema_v1.sql`，路径 `data_root/agent/agent.sqlite`。
+- **RED/观察证据：** 先测试未标记/未知版本/损坏 schema、事务回滚、幂等冲突、lease 丢失、hash chain 篡改和 close 后访问。
+- **实施：** 仿 research nominal DB wrapper；独立 application_id/user_version；保存 session/run/event/approval/idempotency/lease/audit/retention metadata。
+- **重构边界：** 不保存 analysis research domain；不暴露裸 `SQLitePool`；完整敏感 prompt/response 默认不入库。
+- **验收：** 初始化/重开/备份恢复确定；相同 key 同 body replay，相同 key 不同 body conflict；篡改可检测。
+- **提交边界：** schema、adapter、DI 和持久化测试独立提交。
+- **恢复入口：** schema marker 或第一条失败的原子性测试。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/storage -v
+pixi run -e dev pytest packages/apps/tests/integration/test_agent_database_lifecycle.py -v
+pixi run -e dev check
+```
+
+### Task 8：Temporal context、EvidenceEnvelope 与外发策略
+
+**依赖：** Tasks 5、7
+**风险：** 高风险，PIT/数据权利
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.runtime.{temporal_context,egress_policy}`、evidence codec。
+- **RED/观察证据：** future sentinel、缺 snapshot/cutoff、模型覆盖 context、cache key 漏字段、local-only 外发用例先失败。
+- **实施：** 服务端 context factory；完整时间/snapshot/license/egress/authority 校验；evidence hash 与 cache identity 覆盖所有可见性输入。
+- **重构边界：** 不自行发明 knowledge rule，调用现有 owner contract；禁止 wall-clock/latest fallback。
+- **验收：** cutoff 外极值不影响结果、cutoff 内相邻记录可用；禁止外发内容在 provider 调用前被拒绝。
+- **提交边界：** temporal/evidence/egress 与 PIT 测试。
+- **恢复入口：** future sentinel 测试。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_temporal_context.py packages/agent/tests/unit/test_egress_policy.py -v
+pixi run -e dev pytest -m pit
+pixi run -e dev check
+```
+
+### Task 9：Episode、事件重放与版本身份
+
+**依赖：** Tasks 5—8
+**风险：** 行为/审计
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.runtime.{episode,replay}`、Episode reader/writer。
+- **RED/观察证据：** 同一 scripted run 事件顺序或 hash 不稳定、缺模型/prompt/tool/snapshot identity 时先失败。
+- **实施：** 生成 `AgentEpisodeManifest`；持久化输入摘要、版本、tool/action/evidence refs、状态和 hash chain；replay 只重放事件/工具结果，不重复副作用。
+- **重构边界：** replay 不调用 live model，除非显式 comparison mode；comparison 产生新 Episode。
+- **验收：** 相同 fixture 事件和 tool sequence 100% 一致；损坏或缺失 evidence fail closed。
+- **提交边界：** Episode/replay 和 fixtures。
+- **恢复入口：** 第一处 manifest digest 差异。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_episode.py packages/agent/tests/unit/test_replay.py -v
+pixi run -e dev check
+```
+
+### Task 10：本地 eval 数据集与 grader 框架
+
+**依赖：** Task 9
+**风险：** 行为/质量门
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.evals.{cases,runner,graders,report}`、`packages/agent/tests/fixtures/evals/**`。
+- **RED/观察证据：** 添加最小安全失败 case，证明 runner 会把 forbidden action、缺 evidence 和 nondeterministic replay 判失败。
+- **实施：** 定义 versioned case schema；grader 分 deterministic、rule-based、optional model critic；模型 critic 永不覆盖确定性安全结论。
+- **重构边界：** 官方发布报告由本地 runner 生成，不依赖 `/v1/evals` 或云端 trace 存储。
+- **验收：** fixed seed/Fake provider 报告 byte-stable；grader 版本和输入 hash 可追踪。
+- **提交边界：** eval framework 与最小 fixtures。
+- **恢复入口：** 第一条错误分级或不稳定报告。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/evals -v
+pixi run -e dev check
+```
+
+**Wave 1 Exit Gate**
+
+```bash
+pixi run -e dev pytest packages/agent/tests -v
+pixi run -e dev arch-check
+pixi run -e dev check
+git diff --check
+```
+
+Exit：第 13 包边界、Fake/OpenAI provider contract、Agent DB、PIT context、Episode/replay 和 eval harness 全绿；feature flags 仍关闭。
+
+### Wave 2：R5.1 Evidence Copilot
+
+### Task 11：只读 evidence facades
+
+**依赖：** Wave 1、Task 1 inventory
+**风险：** 行为/公共 query
+**状态：** [ ]
+
+- **目标文件或边界：** `queries/research_evidence.py`、`queries/decision_evidence.py` 及 providers。
+- **RED/观察证据：** 为 experiment/factor/strategy/backtest/portfolio/risk/DailyDecision V3 建 contract tests，先证明当前 facade 缺统一 typed evidence 或时间字段。
+- **实施：** 优先组合既有 leaf query；只新增 Agent 确实需要的只读 projection；返回 evidence refs 和完整 provenance。
+- **重构边界：** query 无写入、无 Agent 类型、无 transport、无物理 storage。
+- **验收：** 所有 facade 对缺 snapshot/identity fail closed，R4/R3 旧 API 不变。
+- **提交边界：** application read facades 与测试。
+- **恢复入口：** inventory 中第一项 read capability。
+
+```bash
+pixi run -e dev pytest packages/application/tests/unit/queries/test_research_evidence.py packages/application/tests/unit/queries/test_decision_evidence.py -v
+pixi run -e dev arch-check
+pixi run -e dev check
+```
+
+### Task 12：Evidence function tools 与 grounding
+
+**依赖：** Tasks 8、11
+**风险：** 行为/PIT
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.tools.{research,portfolio,risk,decision}`、grounding builder。
+- **RED/观察证据：** Fake model 选错工具、工具绕过 context、输出缺 evidence refs、tool error 被改写成事实等用例先失败。
+- **实施：** tool 是 application facade 薄适配；输入 schema 不暴露受信 context；输出统一为 `EvidenceEnvelope`；`GroundedAnswer` 每个 claim 关联 evidence。
+- **重构边界：** 工具不计算指标、不访问 storage、不吞掉领域错误。
+- **验收：** tool allowlist 精确；无证据或冲突时拒答；PIT sentinel 保持隔离。
+- **提交边界：** read tools、grounding 和单元测试。
+- **恢复入口：** 第一条 tool contract failure。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/tools packages/agent/tests/unit/test_grounding.py -v
+pixi run -e dev pytest -m pit
+pixi run -e dev check
+```
+
+### Task 13：单 Agent 编排、预算与 guardrails
+
+**依赖：** Tasks 6、9、10、12
+**风险：** 行为/模型安全
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.runtime.{orchestrator,budgets,guardrails}`。
+- **RED/观察证据：** max turns、token/cost/time、重试、tool allowlist、拒答和 provider failure 用例先失败。
+- **实施：** deterministic host loop 管理 RUNNING/PAUSED/FAILED；模型只返回 typed intent；tool-level guardrail 在调用边界校验 authority/context；无 write tool。
+- **重构边界：** 不使用 handoff/multi-agent；不允许 SDK 默认 trace 上传敏感内容。
+- **验收：** 超预算不继续调用；瞬态重试有上限；非瞬态失败不伪造答案；Episode 完整。
+- **提交边界：** read-only orchestrator 和 guardrails。
+- **恢复入口：** 首个预算或状态机失败。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_orchestrator.py packages/agent/tests/unit/test_budgets.py packages/agent/tests/unit/test_guardrails.py -v
+pixi run -e dev check
+```
+
+### Task 14：Session/Run API、SSE、恢复和取消
+
+**依赖：** Tasks 7、13
+**风险：** 行为/公共 API
+**状态：** [ ]
+
+- **目标文件或边界：** `models/agent.py`、`api/routes/agent_routes.py`、OpenAPI registration、registry runtime。
+- **RED/观察证据：** OpenAPI 路径、Idempotency-Key conflict、SSE ordering/Last-Event-ID、cancel race、missing run 用例先失败。
+- **实施：** 落地设计 §11.1 的 session/run/approval routes 中 R5.1 可用部分；SSE 只重放 persisted events；route 薄适配。
+- **重构边界：** 不把 SDK state 暴露为 API DTO；不在 route 执行业务逻辑。
+- **验收：** OpenAPI 稳定、SSE 单调、断线恢复不重复工具、Agent disabled 返回结构化 unavailable。
+- **提交边界：** HTTP/SSE surface 和 integration tests。
+- **恢复入口：** OpenAPI contract 或 SSE first failure。
+
+```bash
+pixi run -e dev pytest packages/apps/tests/unit/test_agent_routes.py packages/apps/tests/integration/test_agent_sse.py -v
+pixi run -e dev check
+```
+
+### Task 15：Agent CLI
+
+**依赖：** Task 14
+**风险：** 行为/入口
+**状态：** [ ]
+
+- **目标文件或边界：** `cli/commands/agent.py` 与 CLI registration。
+- **RED/观察证据：** `run/show/events` help、exit code、JSON/human output、cancel 用例先失败。
+- **实施：** CLI 复用同一 runtime/use case；`--follow` 使用 SSE/repository event reader，不启动旁路 Agent。
+- **重构边界：** 不直接构造 facade/model/storage。
+- **验收：** help、disabled、success、failure、resume/cancel 输出稳定且无 secret。
+- **提交边界：** CLI 和测试。
+- **恢复入口：** 首个 CLI golden mismatch。
+
+```bash
+pixi run -e dev pytest packages/apps/tests/unit/test_cli_agent.py -v
+pixi run -e dev check
+```
+
+### Task 16：R5.1 集成与 eval gate
+
+**依赖：** Tasks 11—15；live profile 另依赖 Approval A4
+**风险：** 高风险，PIT/模型质量
+**状态：** [ ]
+
+- **目标文件或边界：** 30 grounded cases、apps E2E、`docs/evidence/r5/r5.1/**`。
+- **RED/观察证据：** 先运行未满足门槛的基线并保存 report；不得手改 grader 让结果变绿。
+- **实施：** 覆盖 tool choice、事实、证据、冲突、缺失、PIT、provider failure 和 replay；Fake 为硬门，受控 live model 为独立报告。
+- **重构边界：** live 模型失败不影响 deterministic gate；不上传禁止外发 fixture。
+- **验收：** tool/evidence ≥95%，factual ≥90%，必需拒答/PIT/replay 100%。
+- **提交边界：** fixtures、E2E 和 R5.1 evidence。
+- **恢复入口：** 失败率最高的 case family。
+
+```bash
+pixi run -e dev pytest packages/apps/tests/e2e/test_agent_evidence_copilot.py -v
+pixi run -e dev python -m ditto_agent.evals.runner --suite grounded --provider fake
+pixi run -e dev pytest -m pit
+pixi run -e dev check
+```
+
+**Wave 2 Exit Gate：** R5.1 feature flag 可在本机受控打开；read P95/cost、grounding、PIT、SSE resume 和 provider degradation 有 evidence，所有写工具仍未注册。
+
+### Wave 3：R5.2 Author Copilot
+
+### Task 17：草案、compile、validate 与 diff tools
+
+**依赖：** Wave 2
+**风险：** 行为/公共契约
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_agent.tools.author`，既有 StrategySpec/DSL application facade；必要时新增 `queries/authoring_preview.py`。
+- **RED/观察证据：** unknown node、invalid DSL、类型不匹配、canonical diff、模型夹带代码/解释用例先失败。
+- **实施：** 结构化输出只形成草案；由 Ditto compiler/validator 生成诊断和 diff；tool 返回 evidence。
+- **重构边界：** Agent 不实现 parser/compiler；不写正式 strategy 状态。
+- **验收：** invalid 草案 fail closed，canonical preview 可重放，原有 authoring 合同兼容。
+- **提交边界：** author read/draft tools 与 tests。
+- **恢复入口：** 第一条 compile/validate golden。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/tools/test_author_tools.py packages/application/tests/unit/queries/test_authoring_preview.py -v
+pixi run -e dev check
+```
+
+### Task 18：HITL interruption、过期与恢复
+
+**依赖：** Tasks 7、13、17
+**风险：** 高风险，审批
+**状态：** [ ]
+
+- **目标文件或边界：** approval runtime/store、API decision route、SDK interruption adapter。
+- **RED/观察证据：** approve/reject、过期、hash/args/snapshot/budget 篡改、并发双批、restart resume 用例先失败。
+- **实施：** 保存 resumable state 的必要脱敏部分；审批时重新计算 action hash/authority；超时或 storage 不可用 fail closed。
+- **重构边界：** Agent-level guardrail 不替代 tool boundary；审批不能修改 proposed action。
+- **验收：** 只恢复同一 run；变化后必须新审批；决定 append-only 且可审计。
+- **提交边界：** approval lifecycle 与 integration tests。
+- **恢复入口：** 第一条 bypass 或 restart case。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_approval_runtime.py packages/apps/tests/integration/test_agent_approval_resume.py -v
+pixi run -e dev check
+```
+
+### Task 19：正式写入只经 application command
+
+**依赖：** Task 18
+**风险：** 高风险，写行为
+**状态：** [ ]
+
+- **目标文件或边界：** consumer-owned application commands、Agent author write tools、mutation idempotency。
+- **RED/观察证据：** 未审批、审批 hash 不匹配、重复提交、并发提交、agent 直连 store 的架构测试先失败。
+- **实施：** 仅注册设计允许的保存草案/提交 review 等命令；复用 application mutation receipts/idempotency；结果写入 evidence。
+- **重构边界：** 不注册 publish/deprecate/reactivate/order/broker 工具。
+- **验收：** 所有写入有 command receipt、operator approval、run/episode/audit identity；重复请求不重复副作用。
+- **提交边界：** application command 适配、write tools 和 tests。
+- **恢复入口：** 第一条 mutation receipt mismatch。
+
+```bash
+pixi run -e dev pytest packages/application/tests/unit/commands/test_agent_authoring_commands.py packages/agent/tests/unit/tools/test_author_write_tools.py -v
+pixi run -e dev arch-check
+pixi run -e dev check
+```
+
+### Task 20：R5.2 adversarial 与 eval gate
+
+**依赖：** Tasks 17—19
+**风险：** 高风险，权限
+**状态：** [ ]
+
+- **目标文件或边界：** 20 author + 对应 permission cases、`docs/evidence/r5/r5.2/**`。
+- **RED/观察证据：** 保存初始 compile/bypass/篡改失败报告。
+- **实施：** 覆盖 prompt injection、参数夹带、unknown node、approval replay、并发、model/provider failure。
+- **重构边界：** 不降低 compiler、governance 或 approval hard gate 换取通过率。
+- **验收：** author compile/validate ≥90%；approval bypass 100% 阻断；core regression 全绿。
+- **提交边界：** cases 和 R5.2 evidence。
+- **恢复入口：** 失败 case family。
+
+```bash
+pixi run -e dev python -m ditto_agent.evals.runner --suite author --provider fake
+pixi run -e dev python -m ditto_agent.evals.runner --suite permission --provider fake
+pixi run -e dev check
+```
+
+**Wave 3 Exit Gate：** R5.2 flag 独立于 R5.1；草案可生成和验证，任何正式 mutation 都需要不可变审批，发布/交易工具不存在。
+
+### Wave 4：R5.3 Autonomous Research Campaign
+
+### Task 21：Campaign、SearchLedger、代码和记忆领域合同
+
+**依赖：** Wave 1、Task 1 inventory
+**风险：** 高风险，研究公共契约
+**状态：** [ ]
+
+- **目标文件或边界：** analysis 固定目录中的四个新叶模块。
+- **RED/观察证据：** budget、单一 search axis、lineage、attempt/trial、known_at、holdout memory 禁止规则先失败。
+- **实施：** 落地所有 Analysis-owned types；复用既有 identity/content hash/trial family，避免平行概念。
+- **重构边界：** analysis 无调度、无模型、无 sandbox I/O。
+- **验收：** 不变式在构造时 fail closed；对象可脱离 Agent 使用；无 capability 依赖。
+- **提交边界：** 纯研究领域合同和单元测试。
+- **恢复入口：** 第一条 domain invariant。
+
+```bash
+pixi run -e dev pytest packages/analysis/tests/unit/experiments/test_campaign.py packages/analysis/tests/unit/experiments/test_search_ledger.py packages/analysis/tests/unit/experiments/test_research_memory.py -v
+pixi run -e dev arch-check
+pixi run -e dev check
+```
+
+### Task 22：Research SQLite schema 与 migration
+
+**依赖：** Task 21 / Approval A2
+**风险：** 高风险，schema/migration
+**状态：** [ ]
+
+- **目标文件或边界：** 既有 research schema 新版本、campaign/search/memory/code tables、reader/writer protocols。
+- **RED/观察证据：** v1→v2 fixture、rollback、unknown future version、immutable conflict、backup/restore 先失败。
+- **实施：** 前向 migration 保留现有 R3 数据；新表使用 FK/check/unique 和 append-only event；更新 application_id/user_version 验证。
+- **重构边界：** 不新建第二个 analysis DB；不让 Agent 直接使用 analysis reader/writer。
+- **验收：** 空库、现有 v1 fixture、失败回滚、重开、备份恢复全部通过。
+- **提交边界：** migration/schema/ports/adapters 与 tests。
+- **恢复入口：** v1 fixture migration failure。
+
+```bash
+pixi run -e dev pytest packages/analysis/tests/unit/storage/test_campaign_schema_migration.py packages/analysis/tests/integration/test_research_database_restore.py -v
+pixi run -e dev check
+```
+
+### Task 23：Campaign coordinator、授权、预算和恢复
+
+**依赖：** Tasks 18、21、22
+**风险：** 高风险，长流程/权限
+**状态：** [ ]
+
+- **目标文件或边界：** `autonomous_campaign.py`、provider wiring、Agent campaign tool。
+- **RED/观察证据：** immutable hash、预算、两代无改善、lease lost、retry/fork、cancel/restart 用例先失败。
+- **实施：** application coordinator 复用现有 experiment scheduler/lease；Agent 只提出 candidate/feedback；host 决定状态和 stopping。
+- **重构边界：** CampaignAuthorization 不覆盖 holdout/publish/trading；运行中不能扩预算或搜索轴。
+- **验收：** crash resume 不重复 statistical trial；budget exhausted 进入 `PAUSED_BUDGET`；取消幂等。
+- **提交边界：** coordinator、ports、tool 和 tests。
+- **恢复入口：** 第一条 lease/budget transition。
+
+```bash
+pixi run -e dev pytest packages/application/tests/unit/processes/experiments/test_autonomous_campaign.py packages/agent/tests/unit/tools/test_campaign_tool.py -v
+pixi run -e dev check
+```
+
+### Task 24：生成代码 host contract 与可信 evaluator
+
+**依赖：** Tasks 21、23
+**风险：** 高风险，生成代码/回测
+**状态：** [ ]
+
+- **目标文件或边界：** `candidate_sandbox_port.py`、`generated_candidate_evaluator.py`、analysis `generated_code.py`。
+- **RED/观察证据：** 非法 signature、mutable state、指标/权重/订单输出、不同 seed、schema/size mismatch 用例先失败。
+- **实施：** 固定 `fit`/`score`，Arrow/JSON/NumPy allow_pickle=False；宿主提供 visible window，验证输出后调用现有 experiment/backtest/evaluation。
+- **重构边界：** Candidate 不能计算或提交正式 metrics；port 由 application consumer 拥有。
+- **验收：** 相同 input/state/digest/seed 输出确定；非法输出在进入回测前被拒绝。
+- **提交边界：** contract、trusted evaluator 和 fake sandbox tests。
+- **恢复入口：** 第一条 protocol validation failure。
+
+```bash
+pixi run -e dev pytest packages/application/tests/unit/processes/experiments/test_generated_candidate_evaluator.py packages/analysis/tests/unit/experiments/test_generated_code.py -v
+pixi run -e dev check
+```
+
+### Task 25：Hardened OCI sandbox adapter
+
+**依赖：** Task 24 / Approval A3
+**风险：** 高风险，执行不可信代码/运行依赖
+**状态：** [ ]
+
+- **目标文件或边界：** `ditto_apps.registry.agent.oci_sandbox`、固定 Containerfile/image manifest/SBOM、fake adapter。
+- **RED/观察证据：** 网络、socket、Docker socket、host/repo mount、secret、root、write rootfs、fork bomb、OOM、timeout、oversize output 攻击先证明被 harness 捕获。
+- **实施：** macOS Docker Desktop VM profile；Linux rootless OCI + 优先 gVisor；无网、non-root、read-only、tmpfs、cap-drop、no-new-privileges、seccomp、resource limits、digest pin。
+- **重构边界：** 普通 CI 使用 fake；live sandbox acceptance 显式标记；容器内无 package install。
+- **验收：** 10 类攻击全部失败且留下 `SandboxExecutionManifest`；sandbox 不可访问 Docker daemon。
+- **提交边界：** adapter、image、attack harness 和 evidence 独立提交。
+- **恢复入口：** 第一项未被阻断的攻击。
+
+```bash
+pixi run -e dev pytest packages/apps/tests/unit/test_oci_sandbox_adapter.py -v
+pixi run -e dev pytest packages/apps/tests/integration/test_oci_sandbox_security.py -v -m sandbox_live
+pixi run -e dev check
+```
+
+### Task 26：PIT fold、purge/embargo、snapshot 与 future sentinel
+
+**依赖：** Tasks 23—25
+**风险：** 高风险，PIT/回测
+**状态：** [ ]
+
+- **目标文件或边界：** generated evaluator 的 data feed、现有 validation/walk-forward 合同。
+- **RED/观察证据：** cutoff 外极值、late revision、same-close fill、cache key 漏 snapshot、fold boundary 用例先失败。
+- **实施：** 复用现有 dynamic purge/embargo；完整传播 decision/knowledge/publication/snapshot/execution eligibility；每 candidate/fold fresh sandbox。
+- **重构边界：** 不本地发明 `trade_date + 1`；不允许最新 revision fallback。
+- **验收：** sentinel 外不影响、边界内可用；不同 snapshot artifact 不碰撞；同收盘不可成交。
+- **提交边界：** PIT implementation、sentinel tests 和 evidence。
+- **恢复入口：** future sentinel。
+
+```bash
+pixi run -e dev pytest packages/application/tests/unit/processes/experiments/test_generated_candidate_pit.py -v
+pixi run -e dev pytest -m pit
+pixi run -e dev arch-check
+pixi run -e dev check
+```
+
+### Task 27：隐藏 holdout 与一次性评价
+
+**依赖：** Tasks 22、23、26
+**风险：** 高风险，研究治理
+**状态：** [ ]
+
+- **目标文件或边界：** 复用 analysis/application holdout authority，新增 Campaign bridge。
+- **RED/观察证据：** Agent context/tool/event/memory 暴露 holdout 日期、逐期值或重复 claim 用例先失败。
+- **实施：** holdout 独立审批；只返回签名 aggregate pass/fail 和 threshold evidence；消费 append-only 且原子。
+- **重构边界：** CampaignAuthorization 不含 holdout；恢复不能重置 consumption。
+- **验收：** 一次性、并发和 crash case 不重复；holdout 信息不进入 search memory 或 prompt。
+- **提交边界：** holdout bridge、redaction 和 tests。
+- **恢复入口：** 第一条 leakage/reuse case。
+
+```bash
+pixi run -e dev pytest packages/application/tests/unit/processes/experiments/test_agent_campaign_holdout.py packages/analysis/tests/unit/experiments/test_holdout_isolation.py -v
+pixi run -e dev pytest -m pit
+pixi run -e dev check
+```
+
+### Task 28：候选新颖性与 multiple-testing ledger
+
+**依赖：** Tasks 21、24、26
+**风险：** 高风险，统计治理
+**状态：** [ ]
+
+- **目标文件或边界：** SearchLedger bridge、candidate novelty checker、既有 trial family/adjustments。
+- **RED/观察证据：** AST 等价代码、输出高相关、retry/fork 重置 counter、protocol 改变未新 trial 用例先失败。
+- **实施：** canonical AST hash、output correlation、lineage root；operational attempt 与 statistical trial 分离；复用 multiple-testing/PBO/DSR。
+- **重构边界：** 模型 critic 不决定统计接受；不以变量改名制造新候选。
+- **验收：** retry 不加 trial，唯一 candidate×protocol 只计一次，fork 共享 family counter。
+- **提交边界：** novelty/ledger/统计 bridge 和 tests。
+- **恢复入口：** 第一条 trial-count mismatch。
+
+```bash
+pixi run -e dev pytest packages/analysis/tests/unit/experiments/test_agent_search_ledger.py packages/application/tests/unit/processes/experiments/test_candidate_novelty.py -v
+pixi run -e dev check
+```
+
+### Task 29：带 `known_at` 的研究记忆
+
+**依赖：** Tasks 8、21、22、27
+**风险：** 高风险，PIT/长期知识
+**状态：** [ ]
+
+- **目标文件或边界：** research memory domain/storage、application query/command、Agent memory tool。
+- **RED/观察证据：** future outcome、holdout result、未验证模型自评、越 scope 检索、未审批 promotion 用例先失败。
+- **实施：** local/family/global scope；backward known_at query；promotion/revoke append-only；默认只写 local 的验证反馈。
+- **重构边界：** 不做向量库或开放 RAG；检索使用结构化字段与 evidence refs。
+- **验收：** `outcome_known_at <= knowledge_cutoff`；holdout 永不可入库；promotion 有审批和 receipt。
+- **提交边界：** memory contracts/storage/use cases/tools/tests。
+- **恢复入口：** future memory sentinel。
+
+```bash
+pixi run -e dev pytest packages/analysis/tests/unit/experiments/test_research_memory_pit.py packages/application/tests/unit/queries/test_research_memory.py packages/agent/tests/unit/tools/test_memory_tool.py -v
+pixi run -e dev pytest -m pit
+pixi run -e dev check
+```
+
+### Task 30：Campaign API、SSE、CLI 与崩溃恢复
+
+**依赖：** Tasks 23—29
+**风险：** 高风险，公共 API/长流程
+**状态：** [ ]
+
+- **目标文件或边界：** design §11 campaign routes、apps DTO、CLI campaign commands。
+- **RED/观察证据：** create/approve/show/cancel、Idempotency-Key、SSE resume、budget pause、crash lease recovery 用例先失败。
+- **实施：** routes/CLI 薄适配；审批显示 immutable manifest hash 和预算；事件从 persisted store 重放。
+- **重构边界：** API 不允许 patch 运行中 manifest/budget；无 `resume-with-more-budget` 隐式动作。
+- **验收：** lifecycle 与设计状态一致；cancel/recovery 幂等；无 double trial/tool。
+- **提交边界：** public surface、integration/E2E tests。
+- **恢复入口：** 第一条 lifecycle mismatch。
+
+```bash
+pixi run -e dev pytest packages/apps/tests/integration/test_agent_campaign_api.py packages/apps/tests/unit/test_cli_agent_campaign.py -v
+pixi run -e dev check
+```
+
+### Task 31：R5.3 安全、PIT 与 eval gate
+
+**依赖：** Tasks 21—30
+**风险：** 高风险，发布前研究安全
+**状态：** [ ]
+
+- **目标文件或边界：** 30 campaign/PIT/holdout、10 sandbox attacks、相关 permission cases、`docs/evidence/r5/r5.3/**`。
+- **RED/观察证据：** 保存首轮失败报告，按 failure family 修复生产逻辑或 case 事实，不改低门槛。
+- **实施：** 跑 deterministic、PIT、sandbox live 和受控 live-model comparison；验证资源/成本/停止规则。
+- **重构边界：** optional LLM critic 只读；不得覆盖宿主 verdict。
+- **验收：** PIT/holdout/sandbox escape/forbidden action/approval bypass 100%；Campaign replay 和 ledger 确定。
+- **提交边界：** eval cases、evidence 和必要修复各自提交。
+- **恢复入口：** 最严重的安全/PIT failure。
+
+```bash
+pixi run -e dev python -m ditto_agent.evals.runner --suite campaign --provider fake
+pixi run -e dev python -m ditto_agent.evals.runner --suite sandbox --provider fake
+pixi run -e dev pytest -m pit
+pixi run -e dev pytest -m sandbox_live
+pixi run -e dev check
+```
+
+**Wave 4 Exit Gate：** 自主研究只在不可变授权和预算内运行；生成代码隔离；宿主独占金融评价；holdout、multiple-testing、known_at 和恢复均有证据。
+
+### Wave 5：R5.4 Decision Briefing
+
+### Task 32：DailyDecision V3 后生成 `DecisionOpinion`
+
+**依赖：** Wave 2、R4 current inventory
+**风险：** 高风险，决策解释
+**状态：** [ ]
+
+- **目标文件或边界：** Agent `DecisionOpinion`、application `decision_evidence.py`、post-V3 shadow process。
+- **RED/观察证据：** 缺 V3/provenance、blocked V3、证据冲突、模型失败用例先失败。
+- **实施：** 在 V3 持久化成功之后读取不可变报告并生成解释/异议/不确定性；保存独立 shadow identity。
+- **重构边界：** 不改变 V3；不写权重、risk status、action 或 order。
+- **验收：** 同一 V3 hash 生成可追踪 opinion；V3 缺失/blocked 时只解释阻塞或拒答。
+- **提交边界：** shadow process、tool/contract 和 tests。
+- **恢复入口：** V3 evidence fixture。
+
+```bash
+pixi run -e dev pytest packages/application/tests/unit/processes/risk/test_agent_decision_briefing.py packages/agent/tests/unit/test_decision_opinion.py -v
+pixi run -e dev check
+```
+
+### Task 33：证明 shadow 隔离
+
+**依赖：** Task 32
+**风险：** 高风险，交易/风控边界
+**状态：** [ ]
+
+- **目标文件或边界：** EOD/DailyDecision/portfolio/risk/execution regression 与 import/tool registry。
+- **RED/观察证据：** 注入恶意 opinion 试图改变权重、状态、订单或 downstream hash，测试先证明 harness 能观察差异。
+- **实施：** opinion 使用独立 store/event namespace；下游无 consumer；机器测试断言无 publish/order/broker tools。
+- **重构边界：** 不以“暂不调用”代替依赖隔离，需静态和运行时双证据。
+- **验收：** 开/关 shadow 后 DailyDecision V3、建议权重、risk gate、orders byte-identical。
+- **提交边界：** isolation guards 和 regression tests。
+- **恢复入口：** 首个 downstream diff。
+
+```bash
+pixi run -e dev pytest packages/apps/tests/integration/test_agent_shadow_isolation.py packages/application/tests/unit/processes/risk/test_daily_projection.py -v
+pixi run -e dev arch-check
+pixi run -e dev check
+```
+
+### Task 34：Outcome feedback 与 shadow eval
+
+**依赖：** Tasks 29、32、33
+**风险：** 高风险，PIT/模型监控
+**状态：** [ ]
+
+- **目标文件或边界：** opinion outcome linker、10 shadow eval cases、`known_at` feedback。
+- **RED/观察证据：** outcome 在可知前被关联、同日收益泄漏、holdout/未来结果进入 prompt 用例先失败。
+- **实施：** 只在结果实际可知后关联 outcome；记录 adoption/accuracy/calibration，不自动提升 memory。
+- **重构边界：** feedback 不修改历史 opinion 或 V3；promotion 仍需人工。
+- **验收：** future sentinel 100%；10 shadow cases 可重放；无 downstream mutation。
+- **提交边界：** feedback、PIT tests 和 R5.4 evidence。
+- **恢复入口：** outcome known_at sentinel。
+
+```bash
+pixi run -e dev python -m ditto_agent.evals.runner --suite shadow --provider fake
+pixi run -e dev pytest -m pit
+pixi run -e dev check
+```
+
+**Wave 5 Exit Gate：** DecisionOpinion 只读、独立持久化、可做 outcome analysis，核心决策和交易输出完全不变。
+
+### Wave 6：R5.5 发布硬化
+
+### Task 35：OTel、审计、成本和运行指标
+
+**依赖：** Waves 1—5
+**风险：** 行为/隐私
+**状态：** [ ]
+
+- **目标文件或边界：** Agent OTel instrumentation、apps exporter wiring、metrics/audit redaction。
+- **RED/观察证据：** secret/敏感 payload 泄漏、缺 run/tool/approval/cost span、exporter failure 影响业务用例先失败。
+- **实施：** 复用现有 OTel；Langfuse 仅可选 exporter；记录设计 §12.3 字段；redaction 在 export 前执行。
+- **重构边界：** 不改变 SDK 默认行为后直接上线，明确禁用不受控 trace exporter。
+- **验收：** exporter 关闭/失败不影响 run；无 secret/raw prohibited content；cost/latency 可聚合。
+- **提交边界：** observability、redaction、tests。
+- **恢复入口：** trace privacy golden。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_observability.py packages/apps/tests/integration/test_agent_otel_wiring.py -v
+pixi run -e dev check
+```
+
+### Task 36：Retention、feature flags 与降级
+
+**依赖：** Tasks 7、35
+**风险：** 高风险，删除/运营
+**状态：** [ ]
+
+- **目标文件或边界：** apps Agent settings、retention command/job、runbook tests。
+- **RED/观察证据：** 29/30/31 天边界、长保留工件误删、provider/DB/sandbox/exporter unavailable、flags 默认值先失败。
+- **实施：** 固定 flags：`DITTO_AGENT_ENABLED`、`DITTO_AGENT_AUTHOR_ENABLED`、`DITTO_AGENT_CAMPAIGN_ENABLED`、`DITTO_AGENT_DECISION_SHADOW_ENABLED`、`DITTO_AGENT_MODEL_CALLS_ENABLED`，全部默认 false；30 天 cleanup 只删允许的 raw content。
+- **重构边界：** 删除目标由 typed query 精确解析；不递归删除宽目录；审计/approval/formal artifacts 长期保留。
+- **验收：** retention boundary 正确、dry-run 清单可审计、核心 Ditto 在所有 Agent 故障下回归通过。
+- **提交边界：** settings/cleanup/degradation/tests，执行真实清理前另审批。
+- **恢复入口：** retention dry-run diff。
+
+```bash
+pixi run -e dev pytest packages/agent/tests/unit/test_retention.py packages/apps/tests/integration/test_agent_degradation.py packages/apps/tests/unit/test_agent_settings.py -v
+pixi run -e dev check
+```
+
+### Task 37：120 条正式 eval、SLO 与模型对照
+
+**依赖：** Tasks 16、20、31、34—36；live 对照依赖 Approval A4
+**风险：** 发布/模型费用/数据外发
+**状态：** [ ]
+
+- **目标文件或边界：** 完整 eval dataset、benchmark runner、`docs/evidence/r5/release/eval-report.*`。
+- **RED/观察证据：** 先冻结 case/version/hash 和 grader，再运行 baseline；不删除困难 case。
+- **实施：** 跑 30 grounded、20 author、30 campaign/PIT/holdout、20 permission、10 sandbox、10 shadow；balanced/quality 分开报告；计算 P50/P95/cost。
+- **重构边界：** Fake 安全硬门与 live 质量报告分开；模型升级不继承旧结果。
+- **验收：** 达到设计 §13 全部硬门；普通 read/复杂任务满足延迟和成本；零安全/PIT 回退。
+- **提交边界：** 冻结 dataset/grader 后提交，再单独提交结果和经 TDD 的修复。
+- **恢复入口：** 最严重 failure family 或预算暂停点。
+
+```bash
+pixi run -e dev python -m ditto_agent.evals.runner --suite all --provider fake --output docs/evidence/r5/release/eval-report-fake.json
+pixi run -e dev python -m ditto_agent.evals.runner --suite all --provider openai --profile balanced --output docs/evidence/r5/release/eval-report-balanced.json
+pixi run -e dev python -m ditto_agent.evals.runner --suite all --provider openai --profile quality --output docs/evidence/r5/release/eval-report-quality.json
+pixi run -e dev pytest -m pit
+pixi run -e dev pytest -m sandbox_live
+```
+
+### Task 38：Release evidence、runbook 与最终审查
+
+**依赖：** Task 37
+**风险：** 发布
+**状态：** [ ]
+
+- **目标文件或边界：** `docs/evidence/r5/release/**`、runbook、安全说明、OpenAPI/CLI 文档、路线图状态。
+- **RED/观察证据：** release preflight 应先对缺失的 gate/evidence/approval/backup/restore/SLO 返回 fail closed。
+- **实施：** 完成 backup/restore、crash resume、retention dry-run、provider outage、sandbox outage、feature rollback 演练；执行高风险 diff review。
+- **重构边界：** 不因功能完整而自动声明 G4/G5 或自动交易能力；flags 仍默认关闭。
+- **验收：** release preflight PASS；无未记录失败；设计、源码、OpenAPI、CLI、import contracts 和 evidence 一致。
+- **提交边界：** 文档/evidence/状态更新独立提交；PR 前不混入无关变更。
+- **恢复入口：** release preflight 第一项 blocker。
+
+```bash
+pixi run -e dev arch-check
+pixi run -e dev check
+pixi run -e dev ci
+git diff --check
+git status --short
+```
+
+## Approval 点
+
+| ID | 时机 | 必须批准的动作 | 获批证据 |
+|---|---|---|---|
+| A1 | Task 4 前 | 新 `ditto_agent` 包边界、`.importlinter` 规则、精确 `openai-agents` 生产版本范围 | `docs/evidence/r5/preflight/approvals.md`，待填 |
+| A2 | Tasks 7、22 前 | Agent SQLite v1、Research SQLite migration、备份/恢复和 retention schema | 同上，待填 |
+| A3 | Task 25 前 | OCI/gVisor runtime、固定 image digest/SBOM、新运行依赖和安全 profile | 同上，待填 |
+| A4 | 任何 live model 调用前 | 专用 OpenAI project、MAM/ZDR、凭证、预算、license/egress class 和允许数据集 | 同上，待填 |
+
+历史 2026-08-04 对 `openai-agents` 的原则性批准不能替代 A1 的当前版本/API/transitive 证据。Langfuse 不作为生产必需依赖；如后续新增，同样按新生产依赖审批。
+
+## 波次 Exit Gates
+
+| Wave | Exit Gate |
+|---|---|
+| 0 | 当前合同、SDK/OCI 和 approval 事实可审计，无猜测签名 |
+| 1 / R5.0 | 第 13 包、状态/approval、provider、DB、PIT、Episode/replay、eval harness 全绿 |
+| 2 / R5.1 | Grounded read 达标，PIT/证据/SSE/degradation 完整，无写工具 |
+| 3 / R5.2 | Author compile 达标，正式 mutation 全部 HITL+idempotent，无 publish/trading |
+| 4 / R5.3 | Campaign 授权/预算、沙箱、PIT、holdout、ledger、memory 和恢复硬门全过 |
+| 5 / R5.4 | DecisionOpinion shadow-only，开关前后核心交易输出完全一致 |
+| 6 / R5.5 | 120 eval、SLO、成本、retention、备份恢复、runbook、CI 和 review 全过 |
+
+每个生产 Python Wave 至少运行：
+
+```bash
+pixi run -e dev arch-check
+pixi run -e dev check
+git diff --check
+```
+
+涉及 PIT 的 Wave 额外运行：
+
+```bash
+pixi run -e dev pytest -m pit
+```
+
+PR 前运行：
+
+```bash
+pixi run -e dev ci
+git diff --check
+```
+
+## 发布硬门
+
+- forbidden action、future sentinel、approval bypass、holdout leak、sandbox escape：100%。
+- tool choice、evidence coverage：≥95%。
+- factual correctness：≥90%。
+- required abstention：100%。
+- Author compile/validate：≥90%。
+- Episode tool/event replay：100%。
+- Read P95 ≤30 秒且 ≤0.25 美元；复杂任务 P95 ≤60 秒且 ≤0.75 美元。
+- flags 默认关闭；Agent 任意依赖不可用不影响核心 Ditto。
+- 多 Agent 不在本计划实施范围；只有设计文档 §13.4 门槛达到后另立 ADR。
+
+## 恢复状态
+
+- **已完成：** 设计与实施计划文档已接受；代码任务尚未开始。
+- **下一步：** Task 1，冻结 R3/R4/application 真实消费面。
+- **未解决风险：** A1—A4 均待实施时以精确对象收集批准；OpenAI SDK/API 与 OCI runtime 需重新核验当前版本。
+- **最新命令与结果：** 尚无代码实施验证，不得继承本次文档落地检查作为 Wave 证据。
+- **外部等待或 approval：** 无；到对应 Task 前再暂停。

--- a/docs/plans/archive/2026-08-04-agent-capability-plane-phase-a-copilot.md
+++ b/docs/plans/archive/2026-08-04-agent-capability-plane-phase-a-copilot.md
@@ -1,5 +1,7 @@
 # AI Agent Capability Plane — Phase A (Copilot) Implementation Plan
 
+> **归档说明（2026-08-12）**：本文已被 [R5 详细实施计划](../2026-08-12-r5-governed-quant-research-agent-implementation-plan.md) 取代，仅保留为历史施工记录。旧任务中的 SDK 签名、Platform LLM Gateway、Langfuse 强依赖、Agent/application peer 关系和任务顺序均不得作为当前实现依据。
+
 > **执行合同：** 按 Task 顺序推进；风险变更使用对应 Ditto skill；只读且独立的工作可用宿主原生 subagents；每个波次以本文 Exit Gate 与当前 diff 的验证结果为准。
 
 **Goal:** 交付研究 Copilot 的最小可运行垂直切片——`ditto ask "..."` 经 OpenAI Agents SDK 调用一个只读 Copilot agent，agent 通过 `@function_tool` 薄适配器调用既有 application facade（FactorEvaluationFacade），全程 trace 到自托管 Langfuse。
@@ -171,7 +173,7 @@ source_modules = ditto_agent.**
 forbidden_modules = ditto_platform.config.**
 ```
 
-> 同时更新 [boundaries-and-abstraction-standards.md](../architecture/boundaries-and-abstraction-standards.md) 编排层章节，记录 ditto_agent 为 application 同层 peer。
+> 同时更新 [boundaries-and-abstraction-standards.md](../../architecture/boundaries-and-abstraction-standards.md) 编排层章节，记录 ditto_agent 为 application 同层 peer。
 
 **Step 4: 运行验证**
 

--- a/docs/plans/archive/2026-08-04-ai-agent-capability-plane-design.md
+++ b/docs/plans/archive/2026-08-04-ai-agent-capability-plane-design.md
@@ -1,8 +1,10 @@
 # AI/Agent 能力平面设计
 
+> **归档说明（2026-08-12）**：本文已被 [R5 治理型量化研究 Agent 设计](../2026-08-12-r5-governed-quant-research-agent-design.md) 取代，仅保留为历史决策记录。新的权威设计修正了 Agent/application 依赖方向、取消通用 Platform LLM Gateway 与强制 Langfuse、采用单 Agent 确定性运行时，并加入自主研究 Campaign、PIT、隐藏 holdout、OCI 沙箱和模型风险控制。请勿按本文实施。
+
 > **日期**：2026-08-04
 > **状态**：设计稿（待评审）
-> **关联**：定位纠偏见 [2026-08-04-comprehensive-architecture-audit.md](../reviews/2026-08-04-comprehensive-architecture-audit.md) §定位校准；架构边界见 [boundaries-and-abstraction-standards.md](../architecture/boundaries-and-abstraction-standards.md)
+> **关联**：定位纠偏见 [2026-08-04-comprehensive-architecture-audit.md](../../reviews/2026-08-04-comprehensive-architecture-audit.md) §定位校准；架构边界见 [boundaries-and-abstraction-standards.md](../../architecture/boundaries-and-abstraction-standards.md)
 > **决策（已敲定）**：① Agent runtime + tool 层 → 新增 `ditto_agent` 包（application 编排层 peer）；② Provider = **OpenAI**；③ Runtime = **OpenAI Agents SDK**（非自造 loop）；④ Trace = **OTel GenAI 语义约定 + 自托管 Langfuse**；⑤ 同步（对话）/异步（长任务）双模。详情见 §6（新依赖 `openai-agents` / `langfuse` **已批准 2026-08-04**）
 
 ---
@@ -89,7 +91,7 @@ capability 包 → 仍仅 kernel + platform（零改动）
 - `ditto_agent must not import ditto_{strategy,portfolio,risk,execution,backtest,features,data,analysis}` 直接实现（须经 application facade / read-model）
 - `application must not import ditto_agent`（防反向依赖）
 - `ditto_agent must not import ditto_platform.config`（与 application 同纪律，settings 经 dishka 注入）
-- 更新 [boundaries-and-abstraction-standards.md](../architecture/boundaries-and-abstraction-standards.md) 编排层章节
+- 更新 [boundaries-and-abstraction-standards.md](../../architecture/boundaries-and-abstraction-standards.md) 编排层章节
 
 > 这是对"capability 包禁依赖 application"规则的**补充而非破坏**：ditto_agent 不是 capability 包，而是 application 的编排层 peer（与 apps 同级消费 application 输出）。
 
@@ -169,7 +171,7 @@ def factor_ic(factor_id: str, start: str, end: str) -> FactorICReport:
 > - **隐私**：`set_trace_processors()` **替换** SDK 默认处理器，**禁止 trace 回传 OpenAI**，只发自托管 Langfuse；`trace_include_sensitive_data` 按需关。治理写入的审计仍以既有 R3 governance（durable/immutable）为准，agent trace 为辅助。
 > - **新依赖（已批准 2026-08-04）**：`openai-agents`、`langfuse`。Langfuse server 独立部署，不进 Python 依赖树。
 
-填审计 [platform §2.2](../reviews/2026-08-04-comprehensive-architecture-audit.md) flag 的"缺统一 http client / tenacity / limits 封装"——**LLM 网关就是其第一个正经消费者**。
+填审计 [platform §2.2](../../reviews/2026-08-04-comprehensive-architecture-audit.md) flag 的"缺统一 http client / tenacity / limits 封装"——**LLM 网关就是其第一个正经消费者**。
 
 | 组件 | 职责 |
 |------|------|

--- a/docs/reviews/2026-08-04-roadmap-status.md
+++ b/docs/reviews/2026-08-04-roadmap-status.md
@@ -1,8 +1,28 @@
 # Ditto 开发路线图状态评估（2026-08-04）
 
 > **视角**：首席架构师，整合全量源码审计 + AI 能力平面设计 + Capability Benchmark 路线图
-> **基准文档**：[capability-benchmark-design.md §7-§8](../plans/2026-07-10-capability-benchmark-design.md)（阶段与 Release Gate）、[2026-08-04-comprehensive-architecture-audit.md](2026-08-04-comprehensive-architecture-audit.md)（全 12 包审计）、[2026-08-04-ai-agent-capability-plane-design.md](../plans/2026-08-04-ai-agent-capability-plane-design.md)（AI 平面设计）
+> **基准文档**：[capability-benchmark-design.md §7-§8](../plans/2026-07-10-capability-benchmark-design.md)（阶段与 Release Gate）、[2026-08-04-comprehensive-architecture-audit.md](2026-08-04-comprehensive-architecture-audit.md)（全 12 包审计）、[已归档的 2026-08-04 AI 平面设计](../plans/archive/2026-08-04-ai-agent-capability-plane-design.md)（当时的 AI 判断）
 > **状态日期**：2026-08-06（G2 重跑验证通过日 2026-08-05）
+
+---
+
+## 2026-08-12 状态补充（当前裁决）
+
+本文主体是 2026-08-04—08-06 的历史状态快照，不回写当时的审计过程。其“R4
+未开始、旧 Phase A 计划就绪”的当前性结论已经失效：
+
+1. R4 portfolio/risk 与 G3 controls 已由提交 `9ee6c48c`（PR #72）完成。
+2. R5 当前方向已在 GitHub 交易/Stock Agent、成熟交易引擎、OpenAI 官方资料和
+   金融/程序化交易治理材料复核后重构为**治理型量化研究 Agent**。
+3. 新的当前事实源为 [R5 设计](../plans/2026-08-12-r5-governed-quant-research-agent-design.md)
+   与 [38-task 实施计划](../plans/2026-08-12-r5-governed-quant-research-agent-implementation-plan.md)。
+4. 生产默认改为单 Agent + 确定性状态机；R5.3 是预算受限的自主研究 Campaign，
+   多 Agent 仅保留为离线对照，不再作为 R5.3 产品阶段。
+5. `ditto_agent` 的当前依赖方向是 `apps -> agent -> application`，不再使用本文所引
+   旧设计中的 “application peer”、Platform LLM Gateway 或强制 Langfuse 方案。
+
+以下各节保留历史文字，用于说明当时为什么先完成 R4；执行工作不得引用其中的旧
+AI 路径、旧 SDK 示例或旧任务顺序。
 
 ---
 
@@ -100,7 +120,7 @@ G2 经历了一次"假 PASS → 审计推翻 → 合法重过"的完整闭环，
 | **C Agentic 发现** | L3 自主 | evaluation 引擎 + R3 治理 + **R4 组合** | R4 后 |
 | **D 决策回路** | L2/L3 advisory | live daily-decision + **G2 unblock**（策略 publish） | R4 + G2 落地后 |
 
-> AI 平面设计见 [2026-08-04-ai-agent-capability-plane-design.md](../plans/2026-08-04-ai-agent-capability-plane-design.md)；Phase A 实施计划见 [2026-08-04-agent-capability-plane-phase-a-copilot.md](../plans/2026-08-04-agent-capability-plane-phase-a-copilot.md)。
+> 当时的 AI 平面设计见 [归档设计](../plans/archive/2026-08-04-ai-agent-capability-plane-design.md)；Phase A 计划见 [归档计划](../plans/archive/2026-08-04-agent-capability-plane-phase-a-copilot.md)。两者已被 2026-08-12 R5 文档取代。
 
 ---
 
@@ -155,6 +175,8 @@ pixi run -e dev check        # lint + fmt + type + test --fast
 
 - 路线图母版：`docs/plans/2026-07-10-capability-benchmark-design.md`
 - 全量审计：`docs/reviews/2026-08-04-comprehensive-architecture-audit.md`
-- AI 平面设计：`docs/plans/2026-08-04-ai-agent-capability-plane-design.md`
-- Phase A 计划：`docs/plans/2026-08-04-agent-capability-plane-phase-a-copilot.md`
+- 当前 R5 设计：`docs/plans/2026-08-12-r5-governed-quant-research-agent-design.md`
+- 当前 R5 实施计划：`docs/plans/2026-08-12-r5-governed-quant-research-agent-implementation-plan.md`
+- 历史 AI 平面设计：`docs/plans/archive/2026-08-04-ai-agent-capability-plane-design.md`
+- 历史 Phase A 计划：`docs/plans/archive/2026-08-04-agent-capability-plane-phase-a-copilot.md`
 - R3 源码审计（G2 闭环经过）：`docs/reviews/2026-08-04-r3-source-audit.md`

--- a/docs/roadmaps/ditto-development-roadmap.md
+++ b/docs/roadmaps/ditto-development-roadmap.md
@@ -1,7 +1,7 @@
 # Ditto 后续发展规划与分阶段开发设计
 
 > **首次创建**：2026-07-10<br>
-> **最近复核**：2026-07-19<br>
+> **最近复核**：2026-08-12<br>
 > **状态**：母路线图（Roadmap Source of Truth）<br>
 > **北极星**：全球全品类、AI 原生、以证据驱动人工决策的量化平台；十个能力维度最终全部达到 10/10。
 
@@ -17,6 +17,8 @@
 | `docs/plans/2026-07-17-r2-data-product-design.md` | R2 确定性工程实现、详细范围、发布 evidence 缺口与 live Gate；实施 task 见 2026-07-18 R2 implementation plan |
 | `docs/plans/2026-07-19-r3-a-share-research-strategy-governance-design.md` | R3 已确认的发布边界、双黄金路径、架构、研究协议、治理状态机、工作台与 G2 验收 |
 | `docs/plans/2026-07-19-r3-a-share-research-strategy-governance-implementation-plan.md` | R3 W0-W5、22 个 TDD task、精确文件/测试、审批点和跨仓库施工顺序 |
+| `docs/plans/2026-08-12-r5-governed-quant-research-agent-design.md` | R5 产品、架构、PIT、自主研究、沙箱、模型风险与发布门的权威设计 |
+| `docs/plans/2026-08-12-r5-governed-quant-research-agent-implementation-plan.md` | R5.0-R5.5、38 个 TDD task、审批点、波次 Gate 与恢复合同 |
 | `docs/plans/2026-07-10-phase-a-implementation-plan.md` | 已废弃施工属性的历史迁移索引 |
 
 事实冲突时，以验收证据、当前源码/OpenAPI/CLI、能力基准、母路线图、release 计划的顺序判定。
@@ -42,12 +44,10 @@
 - R1 日频人工交易就绪度：**7.9/10，G1 已通过**。
 - 最强项：PIT、promotion evidence、数据血缘、回测严谨性、OMS/对账协议和工程边界。
 - 最大空白：正式 AI runtime、分钟/盘中、全球资产统一模型。
-- R2 确定性工程实现：**DEVELOPMENT PASS**；代码、测试、API、CLI、工作台和
-  fail-closed acceptance runner 已落地。
-- R2 发布缺口：真实 provider entitlement/license、2015/2016 起历史 bootstrap、
-  19 份 live certification、真实性能/恢复和连续运行 evidence 尚未关闭。
-- 当前产品主线：R3 A 股日频研究与策略治理；R1 仍保持本机单操作者、日频、
-  人工审批边界。
+- R2 确定性工程与 live Gate 已完成，R3/G2 已以可复现 evidence 通过。
+- R3 A 股日频研究与策略治理、R4 组合风险与 G3 控制已经完成。
+- 当前产品主线：R5 治理型量化研究 Agent；仍保持本机单操作者、日频、人工审批
+  和非自动交易边界。
 
 ### 3.2 R1 原五个硬阻塞（已清零）
 
@@ -72,9 +72,9 @@
 | I 日频闭环 | R0 产品边界固化 | 目标、评分、文档职责和架构边界稳定 | 已完成，持续维护 | 1-2 人周/次复核 |
 | I 日频闭环 | R1 日频人工交易 MVP | 单操作者本机 Beta，从 EOD 到成交复盘闭环 | 已完成，G1 通过 | 8-12 人周 |
 | I 日频闭环 | R2 A 股日频数据产品 | 19 个核心数据集有区间认证、PIT、DQ、恢复和工作台 | 工程开发完成；真实发布 Gate 并行收口 | 13-19 人周 |
-| II 研究产品化 | R3 A 股日频研究与策略治理 Beta | 双黄金路径的可复现研究、审查、发布与历史版本重新激活闭环 | 设计和实施计划已确认；实施待启动 | 19-26 人周 |
-| II 研究产品化 | R4 组合、风险与复盘 | 组合优化、风险与执行后复盘产品化 | 未开始 | 12-18 人周 |
-| III AI 与盘中 | R5 AI Copilot / Agent v1 | grounded、可评测、HITL 的 AI 投研与建议 | 未开始 | 14-22 人周 |
+| II 研究产品化 | R3 A 股日频研究与策略治理 Beta | 双黄金路径的可复现研究、审查、发布与历史版本重新激活闭环 | 已完成，G2 通过 | 19-26 人周 |
+| II 研究产品化 | R4 组合、风险与复盘 | 组合优化、风险与执行后复盘产品化 | 已完成，G3 控制落地 | 12-18 人周 |
+| III AI 与盘中 | R5 治理型量化研究 Agent | grounded、可评测、HITL、PIT-safe 的 AI 投研、自治研究与 shadow 建议 | 设计与 38-task 实施计划已确认；实施待启动 | 18-26 人周 |
 | III AI 与盘中 | R6 分钟级与盘中 Beta | 分钟数据、增量因子和盘中信号 | 未开始 | 24-36 人周 |
 | IV 全球机构化 | R7 全球全品类扩展 | 多市场、多资产、多账户与机构运营 | 未开始 | 40+ 人周，滚动规划 |
 
@@ -229,7 +229,7 @@ PIT、质量、来源、恢复和 promotion 证据的数据产品，服务本地
 
 ## 9. R3：A 股日频研究与策略治理 Beta
 
-**状态：设计与实施计划已确认（2026-07-19），实施待启动。**
+**状态：已完成，G2 已通过。**
 
 详细设计事实源：
 `docs/plans/2026-07-19-r3-a-share-research-strategy-governance-design.md`；
@@ -305,6 +305,11 @@ R3 保持日频、人工审批和本机边界。
 
 ## 10. R4：组合优化、风险与复盘工作台
 
+**状态：已完成（`9ee6c48c`，PR #72），G3 组合风险控制已落地。**
+
+详细设计事实源：`docs/plans/2026-08-04-r4-portfolio-risk-design.md`；最终施工与
+验收入口：`docs/plans/2026-08-10-r4-portfolio-risk-g3-execution-plan.md`。
+
 ### 目标
 
 把“有信号”提升为“仓位可解释、风险可控、执行后可复盘”的日频决策产品。
@@ -328,54 +333,87 @@ R3 只提供为回测和选股语义服务的确定性基础分配方式，例�
 - 账本重建与存量快照一致，偏差和 PnL 可解释。
 - G3 决策工作台 Beta 的 SLO、告警、runbook 和恢复 Gate 通过。
 
-## 11. R5：AI Copilot / Agent v1
+## 11. R5：治理型量化研究 Agent
 
 ### 目标
 
-在稳定数据、策略、回测、组合和 Daily Decision 上增加 grounded AI，不让模型成为新的事实源或隐形交易者。
+在 R3 可复现研究、R4 组合风险和 Daily Decision V3 之上增加 grounded、可评测、
+可恢复的 AI 研究与决策辅助，不让模型成为新的事实源、回测裁判或隐形交易者。
+
+权威设计：`docs/plans/2026-08-12-r5-governed-quant-research-agent-design.md`；
+逐 Task 施工图：
+`docs/plans/2026-08-12-r5-governed-quant-research-agent-implementation-plan.md`。
 
 ### 技术选择
 
-首个 runtime 采用 OpenAI Agents SDK，使用其 agents、function tools、handoffs、guardrails、sessions、tracing 与 human-in-the-loop interruption/resume。选择是当前路线，不等于当前已有能力，也不阻止未来在模型边界接入其他 provider。
+新增第 13 包 `ditto_agent`，依赖方向固定为
+`apps -> agent -> application -> capabilities`。生产默认采用单 Agent、确定性状态机、
+function tools、服务端状态与 HITL；OpenAI Agents SDK 通过 Agent-owned port 接入，
+不在 platform 建通用 LLM Gateway。OTel 是主观测协议，Langfuse 仅可选 exporter。
+
+首发只使用 Ditto 内部 evidence；禁用开放 Web/RAG/MCP、Hosted Code Interpreter、
+Conversations、Files、Vector Stores 和 Background mode。多 Agent 只做离线对照，
+没有量化增益证据不进入生产运行时。
 
 ### 分层交付
 
-**R5.0 评测与安全底座**
+**R5.0 治理、评测与重放底座**
 
-- 建立宏观解读、报告解读、策略生成、仓位建议的黄金样本与评分 rubric。
-- 定义 token/成本/延迟预算、模型版本、prompt/version、结构化输出 schema。
-- 处理 prompt injection、越权工具调用、敏感数据、幻觉引用和 trace 脱敏。
+- 建立 Agent contracts、canonical action hash、状态机、Agent SQLite、Episode/replay。
+- 建立 Fake/OpenAI provider contract、模型/提示/tool schema 版本与本地 eval harness。
+- 服务端注入 decision/knowledge/publication/snapshot/execution/egress/authority 上下文。
 
-**R5.1 只读 Copilot**
+**R5.1 Evidence Copilot**
 
-- 回测、因子、组合、风险和 Daily Decision 报告解读。
-- 宏观/市场信息分析、带来源 RAG、受控自然语言查询。
-- AI 生成的结论必须附 snapshot、artifact、tool result 与不确定性。
+- 只读解释实验、因子、策略、回测、组合、风险和 Daily Decision V3。
+- 每个 claim 绑定 `EvidenceEnvelope`、snapshot、artifact、PIT 和不确定性。
+- API + SSE + CLI；断线只重放持久化事件，不重复工具副作用。
 
-**R5.2 策略与建议辅助**
+**R5.2 Author Copilot**
 
-- StrategySpec/DSL 生成、参数解释、代码审计和测试建议。
-- 仓位与买卖建议只调用 Ditto tools，并经过 deterministic risk guardrail。
-- 所有写操作与建议发布使用 HITL；状态可序列化并恢复。
+- 生成 StrategySpec/DSL/配置草案，调用现有 compiler/validator 产生诊断与 diff。
+- 正式保存/提交只经 application command，并绑定不可变审批 hash 和幂等 receipt。
+- 不注册 publish、权重、订单或券商工具。
 
-**R5.3 多 Agent（有证据才启用）**
+**R5.3 Autonomous Research Campaign**
 
-- analyst/researcher/portfolio/risk 角色采用 manager-as-tools 或 handoff。
-- 只有单 Agent 基线评测证明多 Agent 提升质量时才增加复杂度。
-- Experience Memory 只保存经验证反馈，不自动把模型输出当经验真相。
+- 一次人工审批不可变 Campaign hash 后，在单一搜索轴和预算内迭代假设、代码、
+  fold 与非 holdout 反馈。
+- 生成代码只在无网 hardened OCI 沙箱运行，输出 score/prediction；财务指标、组合、
+  风险和统计全部由 Ditto 宿主计算。
+- SearchLedger 区分 operational attempt/statistical trial；fork 不能重置多重检验。
+- Holdout 对 Agent 不可见，只允许一次独立审批的签名 aggregate pass/fail。
+
+**R5.4 Decision Briefing**
+
+- 在持久化 Daily Decision V3 之后生成只读 `DecisionOpinion`。
+- opinion 独立存储和评测，不得改变 V3、权重、risk status、订单或执行结果。
+- outcome feedback 必须满足 `outcome_known_at <= knowledge_cutoff`。
+
+**R5.5 发布硬化**
+
+- OTel、tamper-evident audit、成本/预算、30 天允许原文 retention、备份恢复和降级。
+- 120 条正式 eval 覆盖 grounded、author、campaign/PIT/holdout、permission、sandbox
+  attack 与 shadow decision。
+- 所有 feature flags 默认关闭，Agent 依赖失败不影响 Ditto 核心流程。
 
 ### 运营要求
 
-- tracing 记录模型、tool、handoff 和 guardrail，但敏感输入/输出默认不上传。
-- sessions 负责会话连续性，不替代 Ditto 的长期研究 artifact 和审计账本。
-- 每次运行记录模型、prompt、tools、usage、cost、latency、result 和人工反馈。
-- Agent 不直接连接券商；R5 仍以人工建议为边界。
+- balanced profile 为 `gpt-5.6-terra`/medium，quality profile 为
+  `gpt-5.6-sol`/high；任何变更重跑相关 eval。
+- 使用专用 OpenAI project、MAM 或 ZDR、`store=false` 和显式 license/egress policy。
+- 普通 read P95 不超过 30 秒/0.25 美元；复杂任务不超过 60 秒/0.75 美元。
+- 研究 Campaign 默认最多 6 代、128 个唯一候选、384 fold、并发 2、4 小时、
+  20 GiB 临时空间和 8 美元模型预算。
+- Agent 不直接连接券商；R5 始终保持人工决策与非自动交易边界。
 
 ### 验收
 
-- 黄金集质量、grounding、拒答、安全、成本和延迟指标达到预设阈值。
-- 无来源结论、tool 失败和越权请求 fail closed。
-- 敏感 tool 调用可暂停、批准/拒绝并恢复，审批记录可审计。
+- forbidden action、PIT sentinel、审批绕过、holdout 泄漏和 sandbox escape 100% 通过。
+- tool choice/evidence coverage 至少 95%，factual correctness 至少 90%，必须拒答 100%。
+- Author compile/validate 至少 90%，Episode tool/event replay 100% 确定。
+- 多 Agent 只有相同 Episode 上成功率提高至少 5 个百分点或候选接受率提高至少
+  10%、安全无回退且成本/延迟不超过 2 倍，才允许另立 ADR。
 - G4 外部 Beta 前完成认证/RBAC、数据权利、隐私和安全 Gate。
 
 ## 12. R6：分钟级与盘中信号 Beta
@@ -472,34 +510,31 @@ R0
                          └─ R7 ── G6
 ```
 
-允许的准备性并行：
+当前依赖裁决：
 
-- R2 真实 provider、历史、certification、性能、恢复与连续运行 evidence 可和
-  R3 工程实施并行；fixture 或 research-only 结果不能替代 G2 所需 live evidence。
-- R3 后期可制作 AI eval 数据集，但 R5 runtime 仍依赖 R4 稳定 artifacts。
+- R2/R3/G2 与 R4/G3 的确定性宿主已经落地，R5.0、R5.1 可立即开始。
+- R5.3 自主研究复用 R3 experiment/holdout/ledger，R5.4 shadow briefing 复用
+  Daily Decision V3；实施前仍按 Task 1 核对真实叶级合同。
 - R5 与 R6 可在团队资源充足时并行，但共享 API/schema 需先冻结。
 - 安全、备份、SLO、许可和合规按 Gate 持续推进，不受功能 release 串行限制。
 
 ## 17. 优先级与资源配置
 
-### P0：当前 release 与并行 Gate 收口
+### P0：当前 release
 
 - R1 与 G1 保持已完成状态、本机运行边界和回归门禁。
-- R2 确定性工程开发已完成；按 R2 evidence index 并行关闭 entitlement/license、
-  历史、19 份 certification、性能、恢复和连续运行 Gate，不以 fixture 替代。
-- R3 设计与 W0-W5 implementation plan 已确认；下一步从 StrategySpec/registry/
-  typed parameter binding 开始实施，并在数据库 task 前执行显式审批。
+- R2/R3/G2 与 R4/G3 保持已完成状态和回归门禁。
+- R5 从 R5.0 治理基础开始，先冻结真实消费合同，再按四个 Approval 点推进。
 
-### P1：G2 收口
+### P1：R5.1/R5.2
 
-- 在真实 certified snapshot 上完成个股主线和 ETF 回归线，关闭 96 月协议、
-  一次性 holdout、真实 UI、重放和恢复 evidence。
-- 只有 R2 live Gate 与 R3 双黄金路径同时通过，才宣称 G2 日频研究 Beta。
+- 先交付 grounded read 与本地 eval，再增加 Author Copilot 的逐动作 HITL。
+- 不因自然语言体验提前开放 Web/RAG/MCP 或正式 publish/交易动作。
 
-### P2：G2/G3 后
+### P2：R5.3/R5.4
 
-- R4 完成可靠组合与风险事实，R5 才接 AI 建议。
-- AI 与分钟级分别立项，避免两个高不确定性架构改造同时压在核心团队上。
+- 在 hardened OCI、PIT、holdout 与 trial ledger 证据完整后开放受控研究 Campaign。
+- DecisionOpinion 保持 shadow-only，以 outcome analysis 验证价值。
 
 ### P3：验证产品价值后
 
@@ -573,7 +608,6 @@ R1 已按以下顺序完成：
   → G1 evidence
 ```
 
-R1 已通过 G1；R2 确定性工程开发完成、live release evidence 并行收口；R3 设计
-与 22-task implementation plan 已确认，下一实施入口为 W0 StrategySpec v2、
-NodeDescriptor、canonical hash 和 typed parameter binding。AI runtime 和分钟级改造
-继续分别留在 R5、R6，不因 R3 启动而提前进入当前范围。
+R1/G1、R2、R3/G2 和 R4/G3 已完成。R5 治理型量化研究 Agent 的权威设计与
+38-task implementation plan 已于 2026-08-12 冻结，下一实施入口是 Wave 0
+当前合同/SDK/OCI 预检，再进入 R5.0 第 13 包和治理底座。分钟级改造继续留在 R6。


### PR DESCRIPTION
## What changed

- add the authoritative R5 governed quant research agent design
- add a 38-task implementation plan covering R5.0 through R5.5
- archive the superseded 2026-08-04 agent plans with supersession notices
- align the roadmap, roadmap status snapshot, and R4 cross-reference

## Why

The previous plan centered on a looser AI capability plane. The new design incorporates current trading-agent, quant-platform, OpenAI, PIT, sandbox, and financial-governance evidence and fixes the production direction around a single governed agent, deterministic orchestration, controlled research campaigns, and shadow-only decision opinions.

## Impact

Documentation only. No Python code, production dependency, SQLite schema, runtime configuration, broker integration, or production data path is changed.

## Validation

- `git diff --check`
- required document/archive existence checks
- 38-task count check
- stale active-plan phrase and link scans
- local Markdown link validation
