### PR TITLE
docs(agents): configure Matt Pocock engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,20 @@ Web 不导入 Python DTO/源码/存储模型；后端不读取 Web 状态或生�
 - `ditto-change-review`：用户要求 review、PR 前审查，或高风险 diff 完成后的只读审查。
 - `ditto-quality-eval`：仅当用户明确要求全库质量评估时使用。
 
+## Agent skills
+
+### Issue tracker
+
+处理 issue、spec 或 review 的需求来源时，使用 GitHub Issues（`cosmos-arc/ditto`）；先读 [issue tracker 配置](docs/agents/issue-tracker.md)。
+
+### Triage labels
+
+执行 triage 或设置 ticket 状态时，使用五个默认标签；映射见 [triage labels 配置](docs/agents/triage-labels.md)。
+
+### Domain docs
+
+探索领域概念、命名或架构决策前，按 single-context 布局读取文档；规则见 [domain docs 配置](docs/agents/domain.md)。
+
 ## 风险与执行合同
 
 - 普通：局部、可逆、不改变外部行为。完成目标测试与 changed-scope 门禁。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,21 @@
+# Domain Docs
+
+## Layout
+
+采用 **single-context**：根目录 `CONTEXT.md` 存放统一领域词汇表，根目录 `docs/adr/` 存放架构决策。沿用现有 ADR 及其索引。
+
+## Before exploring, read these
+
+- 涉及领域概念或命名时，读取根目录 `CONTEXT.md`。
+- 涉及架构决策时，从 [ADR 索引](../adr/README.md) 选择与任务相关的 ADR。
+- 需要当前能力平面或目录边界时，读取 [架构快速参考](../architecture/agent-context-pack.md) 与 [边界与抽象标准](../architecture/boundaries-and-abstraction-standards.md)。
+
+可选的 CONTEXT 或 ADR 文档不存在时，静默继续；在 `domain-modeling` 实际确定术语或决策时再按需创建。
+
+## Use the glossary's vocabulary
+
+issue 标题、方案、假设、测试名称中的领域概念使用 `CONTEXT.md` 已定义的术语。遇到未定义概念，先核对现有用语；确有缺口时交由 `domain-modeling` 澄清并记录。
+
+## Flag ADR conflicts
+
+建议与现有 ADR 冲突时，明确指出 ADR 编号、冲突内容和重新讨论的理由。事实优先级遵循根目录 [AGENTS.md](../../AGENTS.md)。

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+本仓库的 issue 和 spec 记录在 [cosmos-arc/ditto 的 GitHub Issues](https://github.com/cosmos-arc/ditto/issues)，使用 `gh` CLI 操作。
+
+## Conventions
+
+在此仓库的 worktree 内运行 `gh`，由 Git remote 确定目标仓库；在其他目录运行时显式指定 `--repo cosmos-arc/ditto`。
+
+- 创建：`gh issue create --title "..." --body-file <body.md>`。
+- 读取：`gh issue view <number> --json number,title,body,labels,comments`。
+- 列表：`gh issue list --state open --json number,title,body,labels,comments`，按需添加 `--label` 或调整 `--state`；完整扫描时处理分页或显式设置足够的 `--limit`。
+- 评论：`gh issue comment <number> --body-file <comment.md>`。
+- 添加或移除标签：`gh issue edit <number> --add-label "..."` / `--remove-label "..."`，标签映射见 [triage-labels.md](triage-labels.md)。
+- 关闭：`gh issue close <number>`；需要说明时先发布评论。
+- 多行正文先写入文件，再通过 `--body-file` 传入，保留实际换行。
+
+skill 要求 “publish to the issue tracker” 时，创建 GitHub issue；要求 “fetch the relevant ticket” 时，读取该 issue 的正文、标签与评论。
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+GitHub 的 issue 与 PR 共用编号。引用只给出 `#number` 且类型不明时，先确认资源类型；PR 使用 `gh pr view <number> --comments` 和 `gh pr diff <number>` 读取。
+
+## Wayfinding operations
+
+供 `wayfinder` 使用：
+
+- **Map**：一个标记为 `wayfinder:map` 的 issue，正文包含 Notes、Decisions-so-far 与 Fog。
+- **Child ticket**：每个 ticket 单独建立 issue，标签为 `wayfinder:<type>`，type 为 `research`、`prototype`、`grilling` 或 `task`。用 `gh issue edit <child> --parent <map>` 关联为 GitHub sub-issue；不可用时在 map 中维护 task list，并在 child 正文顶部写 `Part of #<map>`。
+- **Blocking**：优先使用 GitHub 原生 issue dependencies。添加阻塞关系用 `gh issue edit <child> --add-blocked-by <blocker-number>`。不可用时在 child 正文顶部写 `Blocked by: #<n>, #<n>`。
+- **Frontier**：按 map 顺序遍历其开放 child，选第一个未分配且无开放 blocker 的 ticket；通过 `gh issue view <number> --json state,assignees,subIssues,blockedBy` 读取关系，逐一确认 blocker 已关闭；文本关系同样检查引用的 blocker。
+- **Claim**：开始工作前运行 `gh issue edit <number> --add-assignee @me`。
+- **Resolve**：评论记录结果，关闭 child，再用 `gh issue edit <map> --body-file <updated-map.md>` 更新 map 的 Decisions-so-far，保留原正文并追加摘要和链接。

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+五个 canonical triage role 与本仓库的标签同名：
+
+| Canonical role | Tracker label | 含义 |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | 等待维护者评估 |
+| `needs-info` | `needs-info` | 等待报告者补充信息 |
+| `ready-for-agent` | `ready-for-agent` | 规格完整，可交给 Agent 实施 |
+| `ready-for-human` | `ready-for-human` | 需要人工实施 |
+| `wontfix` | `wontfix` | 不予处理 |
+
+skill 提及 triage role 时，使用右侧对应标签；以后调整标签名称时编辑此映射。


### PR DESCRIPTION
## 变更类型

- [x] 📝 docs: 文档变更

## 变更描述

工程 skills 此前缺少仓库级 issue tracker、triage 标签和领域文档约定。新增配置后，issue/spec 使用 `cosmos-arc/ditto` 的 GitHub Issues，triage 使用五个默认标签，领域文档采用 single-context 并沿用现有 ADR。

配置入口加入 `AGENTS.md`，使两个宿主共享规则，并满足 `CLAUDE.md` 必须保持 `@AGENTS.md` wrapper 的机器约束。CONTEXT 词汇表按需创建。

## 影响范围

- [x] 其他：`AGENTS.md` 与 `docs/agents/{issue-tracker,triage-labels,domain}.md`，共四个文档、82 行新增。

## Definition of Done

- [x] 已按确认草稿核对内容、相对链接与仓库指令约束。
- [x] `ditto-change-review` 未发现本次文档变更的可操作缺陷。
- [x] pre-commit 与暂存差异检查通过。
- [ ] 全量 CI 通过：安全扫描失败，因此保留为 Draft。

## 测试说明

- `pixi run --frozen -e dev ci`：后端 16,492 passed / 73 skipped，覆盖率门槛通过；PIT 401 passed；架构约束 43 kept / 0 broken；OpenAPI conformance 4 passed；生产 Web + 隔离后端系统测试 18 passed；Harness 85 tests 与 Agent Eval 15 cases 通过。
- 上述 CI 在 `security-supply-chain` 阶段退出 1：OSV 报告未改动依赖中 11 个包存在 85 个已知漏洞（5 Critical、36 High、36 Medium、4 Low、4 Unknown）。后续 `artifact-gate` 未执行。
- Docker 内的 Git 历史扫描还报告无法解析 worktree 外部 gitdir，因此不能把该部分视为有效的历史扫描通过证据。
- `pixi run --frozen -e dev pre-commit run --files AGENTS.md docs/agents/issue-tracker.md docs/agents/triage-labels.md docs/agents/domain.md`：通过。首次与全量测试并行执行时，Harness 一个子进程超过 2 秒；后续重跑通过。
- `git diff --cached --check`：通过。

## 其他说明

本 PR 只配置工程 skills，不升级依赖或改变安全门禁。后续可直接编辑 `docs/agents/*.md`。
