### PR TITLE
fix(ci): 修复合并后扫描误报并接入 ZCode hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,8 @@ Thumbs.db
 desktop.ini
 .codex/*
 !.codex/hooks.json
+.zcode/*
+!.zcode/config.json
 .cache/ditto-agent-harness/
 .worktrees/
 .merge-backups/

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -128,3 +128,6 @@ docs/evidence/workstation-baseline-20260831.json:generic-api-key:48
 # Verified against https://pypi.org/pypi/parso/0.8.7/json; no credential or rule-wide exception.
 10432325fe30d1c00a2bc24bb82987819b8c794e:uv.lock:square-access-token:4111
 uv.lock:square-access-token:4113
+
+# Same audited parso sdist hash in PR #109 squash commit; v8.18.4 reports diff line 3889.
+47693622e220b37bbe0f12b88bf9dc788c19a639:uv.lock:square-access-token:3889

--- a/.zcode/config.json
+++ b/.zcode/config.json
@@ -1,0 +1,45 @@
+{
+  "hooks": {
+    "enabled": true,
+    "events": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash|Edit|Write",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python3 \"${ZCODE_PROJECT_DIR}/tooling/agent_harness/hook.py\" --host zcode --event pre-tool",
+              "timeout": 10,
+              "statusMessage": "Checking Ditto command policy"
+            }
+          ]
+        }
+      ],
+      "PostToolUse": [
+        {
+          "matcher": "Edit|Write",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python3 \"${ZCODE_PROJECT_DIR}/tooling/agent_harness/hook.py\" --host zcode --event post-tool",
+              "timeout": 10,
+              "statusMessage": "Formatting edited Python files"
+            }
+          ]
+        }
+      ],
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "python3 \"${ZCODE_PROJECT_DIR}/tooling/agent_harness/hook.py\" --host zcode --event stop",
+              "timeout": 3,
+              "statusMessage": "Checking pending changes"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/docs/engineering/agent-harness.md
+++ b/docs/engineering/agent-harness.md
@@ -1,6 +1,6 @@
 # Ditto Agent Harness
 
-Ditto 只维护 Claude Code 与 Codex 两个宿主。Harness 将项目事实、可复用知识、宿主适配和机器门禁分层，避免把通用代理工作流重复包装成项目规则。
+Ditto 只维护 Claude Code、Codex 与 ZCode 三个宿主。Harness 将项目事实、可复用知识、宿主适配和机器门禁分层，避免把通用代理工作流重复包装成项目规则。
 
 ## 结构与事实源
 
@@ -16,6 +16,7 @@ tooling/agent_harness/       同步、验证、hooks、确定性 eval 和测试
   lease.py                   common-dir 单写者 lease
 .claude/settings.json        Claude 薄适配
 .codex/hooks.json            Codex 薄适配
+.zcode/config.json           ZCode 薄适配（hooks 嵌套于 hooks.events，且需 enabled: true）
 ```
 
 `.importlinter` 是依赖边界机器事实源。Task tasks、Ruff、basedpyright、pytest 和 CI 执行质量规则；Markdown 只保留路由、风险和不变量。
@@ -35,6 +36,7 @@ task harness-check
 ```
 
 `sync_skills.py --check` 和 validator 比较完整文件集与字节内容，镜像缺失、额外文件或漂移都会失败。
+Claude 使用生成并提交的 `.claude/skills` 镜像；ZCode 直接读取 `.agents/skills`，无需镜像。
 
 ## Hook 矩阵
 
@@ -44,7 +46,7 @@ task harness-check
 | PostToolUse | Edit/Write/apply_patch | 只对能精确解析出的 Python 文件限时运行 Ruff format；不安装环境、不执行 lint fix |
 | Stop | 全部 | 快速提示工作区仍有改动；不执行测试、查询工具版本或宣称验证通过 |
 
-同步 hooks 的职责是快速反馈，不是每次回复后的 CI。Codex 与 Claude 的预算一致：
+同步 hooks 的职责是快速反馈，不是每次回复后的 CI。三个宿主的预算一致：
 PreToolUse 10 秒；PostToolUse 10 秒（格式化内部 5 秒，超时清理本次进程组）；
 Stop 3 秒。格式化使用 已准备 `.venv` 中的 `ruff format <files>`，仅消费已准备好的
 环境。环境缺失、超时或格式化失败会提供非阻断反馈，不掩盖问题，也不替换已完成工具
@@ -107,7 +109,7 @@ task integrator-lease -- release
 持有者应覆盖生成、验证和最终 diff 检查的完整期间，完成后主动 release。PreToolUse
 在 Edit/Write/apply_patch 前阻断非持有者，也识别 OpenAPI `--write`、Bun/uv lock
 更新和直接重定向到受保护文件等已知 Bash writer；任意 shell 语义无法被完全可靠解析，
-因此显式 `check-changed` 还会对完整 Git changed set 再做同一 lease 检查。validator 检查两个宿主必要事件的 matcher 覆盖与共享命令；允许合法附加配置。
+因此显式 `check-changed` 还会对完整 Git changed set 再做同一 lease 检查。validator 检查三个宿主必要事件的 matcher 覆盖与共享命令（ZCode 事件嵌套于 `hooks.events` 且要求 `enabled: true`，否则视为惰性配置）；允许合法附加配置。
 
 ## Policy 回归
 

--- a/tooling/agent_harness/evidence.py
+++ b/tooling/agent_harness/evidence.py
@@ -38,6 +38,7 @@ _FINGERPRINT_CONFIGS = (
     ".importlinter",
     ".pre-commit-config.yaml",
     ".redocly.yaml",
+    ".zcode/config.json",
     "apps/web/dependency-cruiser.config.mjs",
     "apps/web/package.json",
     "apps/web/tsconfig.base.json",

--- a/tooling/agent_harness/hook.py
+++ b/tooling/agent_harness/hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shared repository hook policy for Claude Code and Codex."""
+"""Shared repository hook policy for Claude Code, Codex, and ZCode."""
 
 from __future__ import annotations
 
@@ -478,7 +478,7 @@ def _is_harness(path: str) -> bool:
             )
         )
         or path.startswith(
-            (".agents/", ".claude/", ".codex/", "tooling/agent_harness/")
+            (".agents/", ".claude/", ".codex/", ".zcode/", "tooling/agent_harness/")
         )
         or path == "docs/engineering/agent-harness.md"
     )
@@ -1076,7 +1076,7 @@ def main() -> int:
         required=True,
         choices=("pre-tool", "post-tool", "stop", "check-changed"),
     )
-    parser.add_argument("--host", choices=("claude", "codex"), default="codex")
+    parser.add_argument("--host", choices=("claude", "codex", "zcode"), default="codex")
     args = parser.parse_args()
 
     root = git_root(Path.cwd())

--- a/tooling/agent_harness/tests/test_hook.py
+++ b/tooling/agent_harness/tests/test_hook.py
@@ -407,7 +407,11 @@ class DiffClassificationTests(unittest.TestCase):
             "contract": ["contracts/openapi/v1.json"],
             "high-risk": ["packages/risk/src/ditto_risk/checks.py"],
             "root": ["pyproject.toml"],
-            "harness": [".codex/hooks.json", "tooling/agent_harness/hook.py"],
+            "harness": [
+                ".codex/hooks.json",
+                ".zcode/config.json",
+                "tooling/agent_harness/hook.py",
+            ],
             "unknown": ["unexpected/new-tool.conf"],
         }
         for name, paths in fixtures.items():
@@ -435,11 +439,11 @@ class DiffClassificationTests(unittest.TestCase):
                 assert classify_diff([path]) == "root"
 
     def test_harness_change_runs_the_complete_root_check(self) -> None:
-        path = ".codex/hooks.json"
+        for path in (".codex/hooks.json", ".zcode/config.json"):
+            with self.subTest(path=path):
+                commands = verification_commands(classify_diff([path]), [path])
 
-        commands = verification_commands(classify_diff([path]), [path])
-
-        assert [" ".join(command) for command in commands] == ["task check"]
+                assert [" ".join(command) for command in commands] == ["task check"]
 
     def test_contract_producers_are_classified_as_contract_changes(self) -> None:
         paths = (

--- a/tooling/agent_harness/tests/test_validation.py
+++ b/tooling/agent_harness/tests/test_validation.py
@@ -92,6 +92,7 @@ class FormatFixtureTests(unittest.TestCase):
                 "apps/web/package.json",
                 ".claude/settings.json",
                 ".codex/hooks.json",
+                ".zcode/config.json",
             ):
                 target = root / relative
                 target.parent.mkdir(parents=True, exist_ok=True)
@@ -142,11 +143,18 @@ class FormatFixtureTests(unittest.TestCase):
                 check=False,
             )
             assert result.returncode == 0, result.stdout + result.stderr
-            for relative in (".codex/hooks.json", ".claude/settings.json"):
+            for relative in (
+                ".codex/hooks.json",
+                ".claude/settings.json",
+                ".zcode/config.json",
+            ):
                 config_path = root / relative
                 original_text = config_path.read_text()
                 broken = json.loads(original_text)
-                for entry in broken["hooks"]["PreToolUse"]:
+                container = broken["hooks"]
+                if relative == ".zcode/config.json":
+                    container = container["events"]
+                for entry in container["PreToolUse"]:
                     for hook in entry["hooks"]:
                         hook["command"] = hook["command"].replace('"', "'")
                 config_path.write_text(json.dumps(broken))
@@ -230,20 +238,25 @@ class FormatFixtureTests(unittest.TestCase):
 
         assert any("apply_patch" in matcher.split("|") for matcher in matchers)
 
-    def test_both_hosts_pre_tool_hooks_cover_structured_writes(self) -> None:
+    def test_all_hosts_pre_tool_hooks_cover_structured_writes(self) -> None:
         expected = {
             "claude": {"Bash", "Edit", "Write"},
             "codex": {"Bash", "Edit", "Write", "apply_patch"},
+            "zcode": {"Bash", "Edit", "Write"},
         }
         paths = {
             "claude": ROOT / ".claude" / "settings.json",
             "codex": ROOT / ".codex" / "hooks.json",
+            "zcode": ROOT / ".zcode" / "config.json",
         }
 
         for host, path in paths.items():
             with self.subTest(host=host):
                 config = json.loads(path.read_text(encoding="utf-8"))
-                entries = config["hooks"]["PreToolUse"]
+                entries = validate_module._host_event_entries(
+                    config["hooks"], host, "PreToolUse"
+                )
+                assert isinstance(entries, list)
                 covered = {
                     tool
                     for entry in entries
@@ -254,6 +267,63 @@ class FormatFixtureTests(unittest.TestCase):
                     for tool in entry["matcher"].split("|")
                 }
                 assert expected[host] <= covered
+
+    def test_zcode_hook_contract_requires_enabled_and_nested_events(self) -> None:
+        command = validate_module._HOST_COMMAND_BASE["zcode"]
+        config: dict[str, object] = {
+            "hooks": {
+                "events": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash|Edit|Write",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": command
+                                    + " --host zcode --event pre-tool",
+                                    "timeout": 10,
+                                }
+                            ],
+                        }
+                    ],
+                    "PostToolUse": [
+                        {
+                            "matcher": "Edit|Write",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": command
+                                    + " --host zcode --event post-tool",
+                                    "timeout": 10,
+                                }
+                            ],
+                        }
+                    ],
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": command + " --host zcode --event stop",
+                                    "timeout": 3,
+                                }
+                            ]
+                        }
+                    ],
+                }
+            }
+        }
+
+        disabled: list[str] = []
+        validate_module._validate_host_hook_contract(config, "zcode", disabled)
+        assert any("enabled" in error for error in disabled)
+
+        hooks = config["hooks"]
+        assert isinstance(hooks, dict)
+        hooks["enabled"] = True
+        enabled: list[str] = []
+        validate_module._validate_host_hook_contract(config, "zcode", enabled)
+        assert enabled == []
 
     def test_inert_host_hook_entries_are_rejected(self) -> None:
         config: dict[str, object] = {

--- a/tooling/agent_harness/validate.py
+++ b/tooling/agent_harness/validate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate Ditto's canonical, polyglot dual-host agent harness."""
+"""Validate Ditto's canonical, polyglot multi-host agent harness."""
 
 from __future__ import annotations
 
@@ -70,6 +70,11 @@ _HOST_MATCHERS = {
         "PostToolUse": {"Edit", "Write", "apply_patch"},
         "Stop": set(),
     },
+    "zcode": {
+        "PreToolUse": {"Bash", "Edit", "Write"},
+        "PostToolUse": {"Edit", "Write"},
+        "Stop": set(),
+    },
 }
 _HOST_COMMAND_BASE = {
     "claude": 'python3 "$CLAUDE_PROJECT_DIR/tooling/agent_harness/hook.py"',
@@ -77,6 +82,7 @@ _HOST_COMMAND_BASE = {
         '/usr/bin/env python3 "$(git rev-parse --show-toplevel)/'
         + 'tooling/agent_harness/hook.py"'
     ),
+    "zcode": 'python3 "${ZCODE_PROJECT_DIR}/tooling/agent_harness/hook.py"',
 }
 
 
@@ -300,10 +306,18 @@ def _event_matchers(config: dict[str, object], event: str) -> set[str]:
     }
 
 
+def _host_event_entries(hooks: dict[object, object], host: str, event: str) -> object:
+    """Resolve per-host event lists; ZCode nests them under hooks.events."""
+    container: object = hooks.get("events") if host == "zcode" else hooks
+    if not isinstance(container, dict):
+        return None
+    return container.get(event)
+
+
 def _validate_host_event(
     hooks: dict[object, object], host: str, event: str, errors: list[str]
 ) -> None:
-    entries = hooks.get(event)
+    entries = _host_event_entries(hooks, host, event)
     if not isinstance(entries, list) or not entries:
         errors.append(f"{host} {event} requires an active shared hook")
         return
@@ -354,6 +368,8 @@ def _validate_host_hook_contract(
     if not isinstance(hooks, dict):
         errors.append(f"{host} hooks must be an object")
         return
+    if host == "zcode" and hooks.get("enabled") is not True:
+        errors.append("zcode hooks must set enabled to true; file hooks are inert")
     for event in sorted(HOOK_EVENTS):
         _validate_host_event(hooks, host, event, errors)
 
@@ -361,8 +377,10 @@ def _validate_host_hook_contract(
 def _validate_host_configs(errors: list[str]) -> None:
     settings_path = ROOT / ".claude" / "settings.json"
     codex_path = ROOT / ".codex" / "hooks.json"
+    zcode_path = ROOT / ".zcode" / "config.json"
     settings = _load_json(settings_path, errors)
     codex = _load_json(codex_path, errors)
+    zcode = _load_json(zcode_path, errors)
 
     if settings is not None:
         plugins = settings.get("enabledPlugins")
@@ -385,8 +403,12 @@ def _validate_host_configs(errors: list[str]) -> None:
         if not any("apply_patch" in matcher.split("|") for matcher in post_matchers):
             errors.append("Codex PostToolUse must match apply_patch")
 
+    if zcode is not None:
+        _validate_host_hook_contract(zcode, "zcode", errors)
+
     _validate_hook_target(settings_path, errors)
     _validate_hook_target(codex_path, errors)
+    _validate_hook_target(zcode_path, errors)
     hook_script = ROOT / "tooling" / "agent_harness" / "hook.py"
     if not hook_script.is_file():
         errors.append("shared hook target is missing")


### PR DESCRIPTION
## 变更描述

PR #109 squash 合并后，Gitleaks 8.18.4 为 uv.lock 中已审计的 parso 0.8.7 sdist SHA-256 生成了新的提交/行号指纹，导致 main 的历史扫描失败。补充该条精确指纹；该哈希已与 PyPI 官方元数据核对，完整历史扫描和其他规则保持启用。

同时提交现有 ZCode 接入修复：使用启用的 hooks.events 配置接入共享 PreToolUse、PostToolUse 和 Stop；校验事件覆盖、命令及启用状态，并将 ZCode 配置纳入变更分类和验证收据。补充测试及维护文档，修正新测试的类型收窄。

## 影响范围

仅密钥扫描误报记录和开发宿主 harness；不修改运行时业务、依赖锁文件、CI 权限或发布流程。

## 验证

- 固定 Gitleaks 8.18.4：main 历史与全部 refs 历史扫描均通过（修复前同一提交可复现失败）。
- pre-commit 全部通过，包括密钥、格式和静态检查。
- 生产与测试 basedpyright：0 errors、0 warnings。
- 根 task check 的后端阶段：15,482 passed、1 Windows skip、1 个未修改的 OCI 墙钟阈值用例失败（9.16 秒超过 8 秒）；该文件独立复测 11 passed，未放宽阈值。
- 随后串行完成剩余 arch-check、check-web、check-contract、harness-check：全部通过；Web 1,757 项，harness 95 项及 114 subtests，tooling 139 项。
- 远端完整 [CI #34202493420](https://github.com/cosmos-arc/ditto/actions/runs/34202493420) 全部通过，包括 Secret history scan、Linux 后端分片、Windows/macOS、覆盖率和 PIT。
- 未进行 ZCode GUI 中的实际宿主发现验收。
